### PR TITLE
feat: add transformation diagram, palette, and transformation schema

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,22 +3,23 @@
 # DxT (Design by Transformation) Project Instructions
 
 This is a React + TypeScript web application for designing dataflow
-diagrams. The current implementation focuses on a visual editor (palette,
-canvas, wiring, selection, property editing, and JSON persistence). Runtime
-execution and transformation application are conceptual extensions, not
-implemented.
+diagrams. The implementation includes a visual editor (palette, canvas,
+wiring, selection, property editing, and JSON persistence) plus a
+transformation library with load/apply/save capabilities.
 
 ## Core Architecture
 
 **Layout:** 30/70 split layout with palette on left, canvas on right, and a
 sliding property editor from the right. Fixed top bar for diagram name,
-save/load/clear.
+save/load/save transformation/clear. Right sidebar hosts the
+Transformation Library.
 
 **Key Components:**
 - `App.tsx` - Main application with state management and event handlers
 - `Canvas.tsx` - Main canvas area with node rendering, wiring, and interactions
 - `Palette.tsx` - Draggable component palette with custom node creation
 - `PropertyEditor.tsx` - Sliding panel for editing node properties
+- `utils/transformation.ts` - Transformation matching and application helpers
 - Modular Canvas components (present but currently not the primary render
 	path): `Node.tsx`, `Port.tsx`, `WireLayer.tsx`, `Lasso.tsx`
 
@@ -30,7 +31,7 @@ save/load/clear.
 - **Node Selection:** Single click to select, Shift+click for multi-select
 - **Lasso Selection:** Click and drag on empty canvas to create selection rectangle
 - **Visual Feedback:** Selected nodes have blue border, glow effect, and dashed outline for multi-select
-- **Context Menu:** Right-click for delete option
+- **Context Menu:** Right-click for delete and apply transformation
 - **Node Types:** Built-in Source/Sink nodes + unlimited custom node types
 - **Properties:** Name, Python file path, description, metadata, input/output
 	port definitions
@@ -70,6 +71,8 @@ save/load/clear.
 
 ### File Operations
 - **Save/Load:** JSON format for complete diagram persistence
+- **Save Transformation:** Export current diagram to transformation JSON
+	based on unwired ports
 - **Data Structure:** Includes nodes, custom node definitions, wires, and diagram metadata
 - **Local File System:** Browser-based file operations with fallback support
 - **File System Access API:** Modern browsers get native file picker
@@ -105,8 +108,8 @@ The application models two transformation types conceptually:
 2. **Optimization:** Replace a node or group with a more efficient
   implementation.
 
-These concepts inform the editor design but are not executed in the current
-codebase.
+These concepts inform the editor design and are supported via a
+Transformation Library and transformation application.
 
 ## Key Implementation Notes
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ graphs. Users drag node types from a palette onto a canvas, wire outputs to
 inputs, and edit node properties in a sliding panel. Diagrams and palettes
 can be saved/loaded as JSON with schema validation.
 
+Transformations can be loaded, saved, and applied to selections based on
+external port patterns.
+
 ## Core Functionality (Concise)
 
 - Drag-and-drop node creation from a palette.
@@ -13,6 +16,7 @@ can be saved/loaded as JSON with schema validation.
 - Clipboard: copy, paste (with wire preservation), delete.
 - Property editing with immediate updates.
 - Diagram save/load (JSON) and palette save/load.
+- Transformation library (load, save, delete) and apply from context menu.
 
 ## Installation
 
@@ -71,6 +75,11 @@ npm test
 6. **Save/Load**: Use the top bar to save or load diagrams as JSON.
 7. **Palette management**: Create custom node types, then save/load palette
    JSON from the palette panel.
+8. **Save transformation**: Use Save Transformation to export the current
+   diagram into a transformation JSON (based on unwired ports). Choose to
+   add it to the Transformation Library.
+9. **Apply transformation**: Right-click a node selection and choose
+   Apply Transformation from the context menu.
 
 ### Keyboard Shortcuts
 
@@ -85,6 +94,8 @@ npm test
 - **Diagram JSON**: Includes diagram name, nodes, custom node definitions,
   and wires. Validated on load.
 - **Palette JSON**: Custom node definitions only (built-ins excluded).
+- **Transformation JSON**: Includes transformation name, input/output
+   patterns, and replacement nodes.
 
 ## Project Structure
 
@@ -104,9 +115,15 @@ DxT/
 │   ├── App.tsx             # Main application component
 │   └── main.tsx            # Application entry point
 ├── test/                   # Test suite
-│   ├── validation-test.cjs
+│   ├── validation-test.mjs
 │   ├── app-functionality.test.cjs
+│   ├── transformation-applicability.test.mjs
+│   ├── transformation-apply.test.mjs
 │   └── run-tests.cjs
+├── samples/                # Sample JSON files
+│   ├── diagram.json
+│   ├── palette.json
+│   └── transformation.json
 ├── public/                 # Static assets
 ├── index.html              # HTML entry point
 ├── Dockerfile              # Container build (multi-stage)

--- a/docs/Theory_of_operation.md
+++ b/docs/Theory_of_operation.md
@@ -20,14 +20,17 @@ Key capabilities include:
 - Palette management (create, save, load custom node types).
 - Diagram persistence to JSON with schema validation on load.
 - Property editing with immediate updates and batch editing support.
+- Transformation library management (load, save, delete transformations).
+- Transformation application based on external port patterns.
 
 ## 2) Application Architecture
 
 ### 2.1 Core Components and Responsibilities
 
 - **App**: Central state owner and coordinator. Holds diagram state,
-  handles file I/O, selection, clipboard, and wire rules. Renders
-  `Palette`, `Canvas`, and the sliding `PropertyEditor`.
+  handles file I/O, selection, clipboard, transformation logic, and wire
+  rules. Renders `Palette`, `Canvas`, the sliding `PropertyEditor`, and the
+  Transformation Library.
 - **Palette**: Left panel with built-in and custom node types. Supports
   creating new node definitions and saving/loading palette JSON. Implements
   drag source behavior for node creation.
@@ -50,6 +53,8 @@ The diagram is represented by three primary collections and a diagram name:
 - **Custom node definitions**: Each definition has `name`, `inputs`,
   `outputs`.
 - **Diagram name**: Used for display and filename generation.
+- **Transformations**: Each transformation defines `name`, `inputPattern`,
+  `outputPattern`, and `replacementNodes`.
 
 Schemas are enforced through JSON validation utilities, ensuring that
 imported diagrams and palettes conform to expected structures.
@@ -61,6 +66,8 @@ State is managed via React `useState` and coordinated in `App`:
 - `nodes`, `wires`, `customNodeDefs`
 - `selectedNodeIds`, `wireDraft`, `clipboard`
 - `diagramName`, `contextMenu`
+- `transformations`, `transformationContextMenu`,
+  `showSaveTransformationModal`, `pendingTransformation`
 
 `Canvas` uses `useRef` for DOM measurements to compute port centers for
 wiring and for lasso selection based on node DOM bounds.
@@ -69,10 +76,11 @@ wiring and for lasso selection based on node DOM bounds.
 
 The layout uses a fixed top bar and a horizontal split:
 
-- **Top bar**: Save, Load, Clear, and diagram name input.
+- **Top bar**: Save, Load, Save Transformation, Clear, and diagram name input.
 - **Left pane**: Palette (approximately 30% width, scrollable).
 - **Right pane**: Canvas (approximately 70% width, scrollable) with a
-  sliding property editor on the far right.
+  sliding property editor on the far right, plus a fixed Transformation
+  Library panel.
 
 Wire rendering is done via SVG polylines, positioned behind nodes and ports
 for clear visual hierarchy.
@@ -133,7 +141,10 @@ multi-selected.
 
 - Right-click on a node to open a context menu. If multiple nodes are
   selected, the menu applies to the selection.
-- The only action in the current menu is Delete.
+- Actions: Delete and Apply Transformation (with applicable transformations).
+
+- Right-click on a transformation card in the Transformation Library to
+  open a context menu with Delete.
 
 ### 3.7 Palette Management
 
@@ -154,6 +165,24 @@ multi-selected.
 - **Load Diagram**: Reads JSON, validates against the diagram schema, and
   updates application state. Invalid files are rejected with a formatted
   error list.
+
+### 3.9 Transformation Management
+
+- **Transformation Library**: A right-side panel listing loaded
+  transformations. Cards show name, input ports, and output ports.
+- **Add Transformation**: Loads a transformation JSON file and validates it
+  against the transformation schema.
+- **Save Transformation**: Exports the current diagram as a transformation.
+  Unwired input ports become `inputPattern`; unwired output ports become
+  `outputPattern`. The transformation name comes from the diagram name
+  field. A modal asks whether to also add it to the library.
+- **Apply Transformation**: From the node context menu, only transformations
+  whose external port multiset matches the selection are shown. External
+  ports include unconnected ports or ports wired to nodes outside the
+  selection. Internal wires are ignored.
+- **Wiring on Apply**: Replacement nodes are offset to the selection’s top
+  left. External wires are reconnected by matching port names; unmatched
+  replacement ports remain unconnected.
 
 ## 4) Implementation Choices and Rationale
 
@@ -209,6 +238,5 @@ locally on Docker Desktop.
 
 The conceptual model supports transformations such as refinement and
 optimization, where a node or subgraph can be replaced by an equivalent
-subgraph with identical interface ports. This document describes the
-current editor; transformation execution and runtime semantics are planned
-extensions.
+subgraph with identical interface ports. Runtime semantics and execution
+are planned extensions.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "node test/run-tests.cjs",
-    "test:validation": "node test/validation-test.cjs",
+    "test:validation": "TS_NODE_PROJECT=tsconfig.app.json TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"ESNext\\\",\\\"moduleResolution\\\":\\\"bundler\\\",\\\"allowImportingTsExtensions\\\":true}\" node --loader ts-node/esm test/validation-test.mjs",
     "test:app": "node test/app-functionality.test.cjs"
   },
   "dependencies": {

--- a/samples/diagram.json
+++ b/samples/diagram.json
@@ -1,0 +1,93 @@
+{
+  "name": "Sample Transformation Diagram",
+  "nodes": [
+    {
+      "id": "node-1",
+      "type": "Source",
+      "x": 120,
+      "y": 120,
+      "properties": {
+        "name": "Source",
+        "inputs": [],
+        "outputs": ["out"],
+        "description": "Sample data source"
+      }
+    },
+    {
+      "id": "node-2",
+      "type": "Filter",
+      "x": 320,
+      "y": 120,
+      "properties": {
+        "name": "Filter",
+        "inputs": ["in"],
+        "outputs": ["out"],
+        "description": "Filters outliers"
+      }
+    },
+    {
+      "id": "node-3",
+      "type": "Normalize",
+      "x": 520,
+      "y": 120,
+      "properties": {
+        "name": "Normalize",
+        "inputs": ["in"],
+        "outputs": ["out"],
+        "description": "Normalizes values"
+      }
+    },
+    {
+      "id": "node-4",
+      "type": "Sink",
+      "x": 720,
+      "y": 120,
+      "properties": {
+        "name": "Sink",
+        "inputs": ["in"],
+        "outputs": [],
+        "description": "Sample data sink"
+      }
+    }
+  ],
+  "customNodeDefs": [
+    {
+      "name": "Filter",
+      "inputs": ["in"],
+      "outputs": ["out"]
+    },
+    {
+      "name": "Normalize",
+      "inputs": ["in"],
+      "outputs": ["out"]
+    },
+    {
+      "name": "Scale",
+      "inputs": ["in"],
+      "outputs": ["out"]
+    }
+  ],
+  "wires": [
+    {
+      "id": "wire-1",
+      "fromNodeId": "node-1",
+      "fromPortIdx": 0,
+      "toNodeId": "node-2",
+      "toPortIdx": 0
+    },
+    {
+      "id": "wire-2",
+      "fromNodeId": "node-2",
+      "fromPortIdx": 0,
+      "toNodeId": "node-3",
+      "toPortIdx": 0
+    },
+    {
+      "id": "wire-3",
+      "fromNodeId": "node-3",
+      "fromPortIdx": 0,
+      "toNodeId": "node-4",
+      "toPortIdx": 0
+    }
+  ]
+}

--- a/samples/palette.json
+++ b/samples/palette.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Filter",
+    "inputs": ["in"],
+    "outputs": ["out"]
+  },
+  {
+    "name": "Normalize",
+    "inputs": ["in"],
+    "outputs": ["out"]
+  },
+  {
+    "name": "Scale",
+    "inputs": ["in"],
+    "outputs": ["out"]
+  },
+  {
+    "name": "OptimizedFilter",
+    "inputs": ["in"],
+    "outputs": ["out"]
+  }
+]

--- a/samples/transformation.json
+++ b/samples/transformation.json
@@ -1,0 +1,20 @@
+{
+  "name": "Filter + Normalize -> OptimizedFilter",
+  "inputPattern": ["in"],
+  "outputPattern": ["out"],
+  "replacementNodes": [
+    {
+      "id": "opt-1",
+      "type": "OptimizedFilter",
+      "x": 320,
+      "y": 120,
+      "properties": {
+        "name": "OptimizedFilter",
+        "inputs": ["in"],
+        "outputs": ["out"],
+        "description": "Optimized combined filter + normalize",
+        "pythonFile": "pipelines/optimized_filter.py"
+      }
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react'
 import Palette from './components/Palette'
 import Canvas from './components/Canvas'
 import PropertyEditor from './components/PropertyEditor'
-import { validateDiagram, formatValidationErrors } from './utils/validation'
+import { validateDiagram, validateTransformation, formatValidationErrors } from './utils/validation'
+import { applyTransformationToSelection, buildTransformationFromDiagram, getApplicableTransformations, getPortList } from './utils/transformation'
 import './App.css'
 import './index.css'
 
@@ -31,13 +32,31 @@ export type WireType = {
   toPortIdx: number
 }
 
+export type TransformationType = {
+  name: string
+  inputPattern: string[]
+  outputPattern: string[]
+  replacementNodes: NodeType[]
+}
+
+const builtInNodeDefs: NodeTypeDef[] = [
+  { name: 'Source', inputs: [], outputs: ['out'] },
+  { name: 'Sink', inputs: ['in'], outputs: [] },
+]
+
+const areStringArraysEqual = (a: string[], b: string[]) => a.length === b.length && a.every((v, i) => v === b[i])
+
 function App() {
   const [nodes, setNodes] = useState<NodeType[]>([])
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([])
 
   const [customNodeDefs, setCustomNodeDefs] = useState<NodeTypeDef[]>([])
+  const [transformations, setTransformations] = useState<TransformationType[]>([])
   const [showPropertyModal, setShowPropertyModal] = useState(false)
+  const [showSaveTransformationModal, setShowSaveTransformationModal] = useState(false)
+  const [pendingTransformation, setPendingTransformation] = useState<TransformationType | null>(null)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeIds: string[] } | null>(null)
+  const [transformationContextMenu, setTransformationContextMenu] = useState<{ x: number; y: number; index: number } | null>(null)
   const [wires, setWires] = useState<WireType[]>([])
   const [wireDraft, setWireDraft] = useState<{
     fromNodeId: string
@@ -57,13 +76,8 @@ function App() {
 
   // Handler for dropping a node from the palette
   const handleDropNode = (type: string, x: number, y: number) => {
-    // Built-in node definitions
-    const builtInDefs = [
-      { name: 'Source', inputs: [], outputs: ['out'] },
-      { name: 'Sink', inputs: ['in'], outputs: [] },
-    ];
     // Look up node definition in built-in and custom node defs
-    const def = [...builtInDefs, ...customNodeDefs].find(d => d.name === type)
+    const def = [...builtInNodeDefs, ...customNodeDefs].find(d => d.name === type)
     setNodes([...nodes, {
       id: `node-${Date.now()}`,
       type,
@@ -134,6 +148,71 @@ function App() {
   // Cancel draft wire if not completed
   const handleCancelWire = () => setWireDraft(null)
 
+  const ensurePaletteDefs = (replacementNodes: NodeType[]) => {
+    const toNodeDef = (node: NodeType): NodeTypeDef | null => {
+      const inputs = getPortList(node.properties, 'inputs')
+      const outputs = getPortList(node.properties, 'outputs')
+      if (!node.type) return null
+      return { name: node.type, inputs, outputs }
+    }
+
+    setCustomNodeDefs(prev => {
+      const existing = [...builtInNodeDefs, ...prev]
+      const toAdd: NodeTypeDef[] = []
+      replacementNodes.forEach(node => {
+        const def = toNodeDef(node)
+        if (!def) return
+        const exists = existing.some(d => d.name === def.name && areStringArraysEqual(d.inputs, def.inputs) && areStringArraysEqual(d.outputs, def.outputs))
+        const alreadyQueued = toAdd.some(d => d.name === def.name && areStringArraysEqual(d.inputs, def.inputs) && areStringArraysEqual(d.outputs, def.outputs))
+        if (!exists && !alreadyQueued) {
+          toAdd.push(def)
+        }
+      })
+      return toAdd.length > 0 ? [...prev, ...toAdd] : prev
+    })
+  }
+
+  const handleAddTransformation = () => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json,application/json'
+    input.onchange = (e: Event) => {
+      const file = (e.target as HTMLInputElement).files?.[0]
+      if (!file) return
+      const reader = new FileReader()
+      reader.onload = (event) => {
+        try {
+          const data = JSON.parse(event.target?.result as string)
+          const validationErrors = validateTransformation(data)
+          if (validationErrors.length > 0) {
+            const errorMessage = formatValidationErrors(validationErrors)
+            alert(`Invalid transformation file:\n${errorMessage}`)
+            return
+          }
+          setTransformations(prev => [...prev, data as TransformationType])
+        } catch (error) {
+          alert(`Failed to load transformation: ${error instanceof Error ? error.message : 'Invalid JSON file.'}`)
+        }
+      }
+      reader.readAsText(file)
+    }
+    input.click()
+  }
+
+  const handleApplyTransformation = (transformation: TransformationType, nodeIds: string[]) => {
+    const result = applyTransformationToSelection(nodes, wires, nodeIds, transformation)
+    if (!result) {
+      alert('Selected nodes do not match the transformation requirements.')
+      return
+    }
+
+    ensurePaletteDefs(result.replacementNodes)
+    setNodes(result.nodes)
+    setWires(result.wires)
+    setSelectedNodeIds(result.selectedNodeIds)
+    setContextMenu(null)
+  }
+
   // Save to local filesystem as JSON file
   const handleSave = () => {
     const saveData = {
@@ -190,13 +269,59 @@ function App() {
     input.click()
   }
 
+  const saveTransformationToFile = (transformation: TransformationType) => {
+    const json = JSON.stringify(transformation, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${transformation.name.replace(/[^a-zA-Z0-9-_]+/g, '_') || 'transformation'}.json`
+    document.body.appendChild(a)
+    a.click()
+    setTimeout(() => {
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    }, 0)
+  }
+
+  const handleSaveTransformation = () => {
+    const transformation = buildTransformationFromDiagram(nodes, wires, diagramName)
+    setPendingTransformation(transformation)
+    setShowSaveTransformationModal(true)
+  }
+
+  const handleSaveTransformationDecision = (addToLibrary: boolean) => {
+    if (!pendingTransformation) {
+      setShowSaveTransformationModal(false)
+      return
+    }
+    saveTransformationToFile(pendingTransformation)
+    if (addToLibrary) {
+      setTransformations(prev => [...prev, pendingTransformation])
+    }
+    setPendingTransformation(null)
+    setShowSaveTransformationModal(false)
+  }
+
   // Context menu handlers
   const handleNodeContextMenu = (e: React.MouseEvent, nodeId: string) => {
     e.preventDefault()
     const nodeIds = selectedNodeIds.includes(nodeId) ? selectedNodeIds : [nodeId]
+    setSelectedNodeIds(nodeIds)
     setContextMenu({ x: e.clientX, y: e.clientY, nodeIds })
   }
   const handleCloseContextMenu = () => setContextMenu(null)
+  const handleCloseTransformationContextMenu = () => setTransformationContextMenu(null)
+
+  const handleTransformationContextMenu = (e: React.MouseEvent, index: number) => {
+    e.preventDefault()
+    setTransformationContextMenu({ x: e.clientX, y: e.clientY, index })
+  }
+
+  const handleDeleteTransformation = (index: number) => {
+    setTransformations(prev => prev.filter((_, i) => i !== index))
+    setTransformationContextMenu(null)
+  }
 
   // Property modal handlers
   const handleClosePropertyModal = () => setShowPropertyModal(false)
@@ -256,6 +381,10 @@ function App() {
     setSelectedNodeIds([])
   }
 
+  const applicableTransformations = contextMenu
+    ? getApplicableTransformations(nodes, wires, contextMenu.nodeIds, transformations)
+    : []
+
   return (
     <div style={{ display: 'flex', height: '100vh', minWidth: 1000, maxWidth: '100vw', overflowX: 'auto' }}>
       <div style={{ position: 'fixed', top: 0, left: 0, width: '100vw', height: 48, background: '#f5f5f5', borderBottom: '1px solid #ccc', zIndex: 20, display: 'flex', alignItems: 'center', paddingLeft: 16 }}>
@@ -268,6 +397,7 @@ function App() {
         />
         <button onClick={handleSave} style={{ marginRight: 8 }}>Save</button>
         <button onClick={handleLoad} style={{ marginRight: 8 }}>Load</button>
+        <button onClick={handleSaveTransformation} style={{ marginRight: 8 }}>Save Transformation</button>
         <button onClick={handleClear}>Clear Diagram</button>
       </div>
       <Palette
@@ -294,37 +424,105 @@ function App() {
           onPasteNodes={handlePasteNodes}
           onDeleteNodes={handleDeleteNodes}
         />
-        {/* Sliding Property Editor */}
-        <div
-          style={{
-            position: 'fixed',
-            top: 48, // only top bar
-            right: 0,
-            height: 'calc(100vh - 48px)',
-            width: 320,
-            background: '#f9f9f9',
-            borderLeft: '1px solid #ccc',
-            boxShadow: '-2px 0 8px rgba(0,0,0,0.07)',
-            zIndex: 30,
-            transform: selectedNodeIds.length === 1 ? 'translateX(0)' : 'translateX(100%)',
-            transition: 'transform 0.3s cubic-bezier(.4,0,.2,1)',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          {selectedNodeIds.length === 1 && (
-            <PropertyEditor
-              nodes={nodes.filter(n => selectedNodeIds.includes(n.id))}
-              onUpdateNode={handleUpdateNode}
-              immediate
-            />
+      </div>
+      {/* Right Sidebar */}
+      <div
+        style={{
+          position: 'fixed',
+          top: 48,
+          right: 0,
+          height: 'calc(100vh - 48px)',
+          width: 320,
+          background: '#f0f0f0',
+          borderLeft: '1px solid #ccc',
+          boxShadow: '-2px 0 8px rgba(0,0,0,0.07)',
+          zIndex: 25,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <div style={{ padding: 12, borderBottom: '1px solid #ddd', background: '#f5f5f5' }}>
+          <h3 style={{ margin: 0, marginBottom: 8 }}>Transformation Library</h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 220, overflowY: 'auto' }}>
+            {transformations.length === 0 && (
+              <div style={{ color: '#777', fontSize: 12 }}>No transformations loaded.</div>
+            )}
+            {transformations.map((t, idx) => (
+              <div
+                key={`${t.name}-${idx}`}
+                onContextMenu={e => handleTransformationContextMenu(e, idx)}
+                style={{ background: '#fff', border: '1px solid #ccc', borderRadius: 6, padding: 8, cursor: 'context-menu' }}
+              >
+                <div style={{ fontWeight: 600 }}>{t.name}</div>
+                <div style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
+                  In: {t.inputPattern.join(', ') || 'none'}
+                </div>
+                <div style={{ fontSize: 12, color: '#666' }}>
+                  Out: {t.outputPattern.join(', ') || 'none'}
+                </div>
+              </div>
+            ))}
+          </div>
+          <button onClick={handleAddTransformation} style={{ marginTop: 10, width: '100%' }}>Add Transformation</button>
+        </div>
+        <div style={{ position: 'relative', flex: 1, overflow: 'hidden' }}>
+          {selectedNodeIds.length !== 1 && (
+            <div style={{ padding: 12, color: '#777' }}>Select a single node to edit properties.</div>
           )}
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              left: 0,
+              bottom: 0,
+              background: '#f9f9f9',
+              transform: selectedNodeIds.length === 1 ? 'translateX(0)' : 'translateX(100%)',
+              transition: 'transform 0.3s cubic-bezier(.4,0,.2,1)',
+              overflowY: 'auto',
+            }}
+          >
+            {selectedNodeIds.length === 1 && (
+              <PropertyEditor
+                nodes={nodes.filter(n => selectedNodeIds.includes(n.id))}
+                onUpdateNode={handleUpdateNode}
+                immediate
+              />
+            )}
+          </div>
         </div>
       </div>
       {/* Context Menu */}
       {contextMenu && (
         <div style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x, background: '#fff', border: '1px solid #ccc', zIndex: 100, boxShadow: '0 2px 8px rgba(0,0,0,0.15)' }} onMouseLeave={handleCloseContextMenu}>
-          <div style={{ padding: 8, cursor: 'pointer', color: 'red' }} onClick={handleDeleteNodes}>Delete</div>
+          <div style={{ padding: 8, cursor: 'pointer', color: 'red' }} onClick={() => { handleDeleteNodes(); handleCloseContextMenu(); }}>Delete</div>
+          <div style={{ padding: 8, borderTop: '1px solid #eee', fontWeight: 600 }}>Apply Transformation</div>
+          {applicableTransformations.length === 0 ? (
+            <div style={{ padding: 8, color: '#888' }}>No applicable transformations</div>
+          ) : (
+            applicableTransformations.map((t, idx) => (
+              <div
+                key={`${t.name}-${idx}`}
+                style={{ padding: 8, cursor: 'pointer' }}
+                onClick={() => handleApplyTransformation(t, contextMenu.nodeIds)}
+              >
+                {t.name}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+      {transformationContextMenu && (
+        <div
+          style={{ position: 'fixed', top: transformationContextMenu.y, left: transformationContextMenu.x, background: '#fff', border: '1px solid #ccc', zIndex: 110, boxShadow: '0 2px 8px rgba(0,0,0,0.15)' }}
+          onMouseLeave={handleCloseTransformationContextMenu}
+        >
+          <div
+            style={{ padding: 8, cursor: 'pointer', color: 'red' }}
+            onClick={() => handleDeleteTransformation(transformationContextMenu.index)}
+          >
+            Delete
+          </div>
         </div>
       )}
       {/* Property Modal */}
@@ -334,6 +532,21 @@ function App() {
           onClose={handleClosePropertyModal}
           onSave={handleUpdateNodeProperties}
         />
+      )}
+      {/* Save Transformation Modal */}
+      {showSaveTransformationModal && (
+        <div style={{ position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh', background: 'rgba(0,0,0,0.35)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 200 }}>
+          <div style={{ background: '#fff', padding: 24, borderRadius: 8, minWidth: 360, boxShadow: '0 2px 16px rgba(0,0,0,0.2)' }}>
+            <h3 style={{ marginTop: 0 }}>Add Transformation to Library?</h3>
+            <p style={{ marginBottom: 20, color: '#444' }}>
+              Save this transformation and add it to the Transformation Library?
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button type="button" onClick={() => handleSaveTransformationDecision(true)}>Yes, add</button>
+              <button type="button" onClick={() => handleSaveTransformationDecision(false)}>No, just save</button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/schemas/transformationSchema.ts
+++ b/src/schemas/transformationSchema.ts
@@ -1,0 +1,100 @@
+// JSON Schema for transformation files
+export const transformationSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  title: "DxT Transformation Schema",
+  description: "Schema for DxT transformation files",
+  required: ["name", "inputPattern", "outputPattern", "replacementNodes"],
+  properties: {
+    name: {
+      type: "string",
+      description: "The name of the transformation",
+      minLength: 1
+    },
+    inputPattern: {
+      type: "array",
+      description: "List of required input port names",
+      items: {
+        type: "string",
+        minLength: 1
+      }
+    },
+    outputPattern: {
+      type: "array",
+      description: "List of required output port names",
+      items: {
+        type: "string",
+        minLength: 1
+      }
+    },
+    replacementNodes: {
+      type: "array",
+      description: "Nodes that replace the selected nodes",
+      items: {
+        type: "object",
+        required: ["id", "type", "x", "y", "properties"],
+        properties: {
+          id: {
+            type: "string",
+            description: "Unique identifier for the node",
+            minLength: 1
+          },
+          type: {
+            type: "string",
+            description: "Type of the node",
+            minLength: 1
+          },
+          x: {
+            type: "number",
+            description: "X coordinate of the node"
+          },
+          y: {
+            type: "number",
+            description: "Y coordinate of the node"
+          },
+          properties: {
+            type: "object",
+            description: "Node properties",
+            properties: {
+              name: {
+                type: "string",
+                description: "Display name of the node"
+              },
+              pythonFile: {
+                type: "string",
+                description: "Path to the Python file for this node"
+              },
+              description: {
+                type: "string",
+                description: "Description of the node"
+              },
+              metadata: {
+                type: "string",
+                description: "Additional metadata as JSON string"
+              },
+              inputs: {
+                type: "array",
+                description: "Array of input port names",
+                items: {
+                  type: "string",
+                  minLength: 1
+                }
+              },
+              outputs: {
+                type: "array",
+                description: "Array of output port names",
+                items: {
+                  type: "string",
+                  minLength: 1
+                }
+              }
+            },
+            additionalProperties: true
+          }
+        },
+        additionalProperties: false
+      }
+    }
+  },
+  additionalProperties: false
+} as const;

--- a/src/utils/transformation.ts
+++ b/src/utils/transformation.ts
@@ -1,0 +1,204 @@
+import type { NodeType, WireType, TransformationType } from '../App'
+
+type ExternalInputPort = { name: string; wire: WireType | null }
+type ExternalOutputPort = { name: string; wires: WireType[] }
+
+export const getPortList = (props: Record<string, unknown>, key: 'inputs' | 'outputs'): string[] => {
+  const val = props[key]
+  if (Array.isArray(val) && val.every(p => typeof p === 'string')) {
+    return val as string[]
+  }
+  return []
+}
+
+const countPortNames = (ports: string[]) => {
+  const counts: Record<string, number> = {}
+  ports.forEach(name => {
+    counts[name] = (counts[name] || 0) + 1
+  })
+  return counts
+}
+
+export const arePortMultisetsEqual = (a: string[], b: string[]) => {
+  const aCounts = countPortNames(a)
+  const bCounts = countPortNames(b)
+  const aKeys = Object.keys(aCounts)
+  const bKeys = Object.keys(bCounts)
+  if (aKeys.length !== bKeys.length) return false
+  return aKeys.every(key => aCounts[key] === bCounts[key])
+}
+
+export const getExternalPorts = (nodes: NodeType[], wires: WireType[], nodeIds: string[]) => {
+  const selectedSet = new Set(nodeIds)
+  const selectedNodes = nodes.filter(n => selectedSet.has(n.id))
+  const externalInputs: ExternalInputPort[] = []
+  const externalOutputs: ExternalOutputPort[] = []
+
+  selectedNodes.forEach(node => {
+    const inputs = getPortList(node.properties, 'inputs')
+    inputs.forEach((name, idx) => {
+      const wire = wires.find(w => w.toNodeId === node.id && w.toPortIdx === idx) || null
+      if (!wire || !selectedSet.has(wire.fromNodeId)) {
+        externalInputs.push({ name, wire })
+      }
+    })
+
+    const outputs = getPortList(node.properties, 'outputs')
+    outputs.forEach((name, idx) => {
+      const outgoing = wires.filter(w => w.fromNodeId === node.id && w.fromPortIdx === idx)
+      const external = outgoing.filter(w => !selectedSet.has(w.toNodeId))
+      if (external.length > 0 || outgoing.length === 0) {
+        externalOutputs.push({ name, wires: external })
+      }
+    })
+  })
+
+  return { externalInputs, externalOutputs }
+}
+
+export const getApplicableTransformations = (
+  nodes: NodeType[],
+  wires: WireType[],
+  nodeIds: string[],
+  transformations: TransformationType[]
+) => {
+  if (nodeIds.length === 0) return []
+  const { externalInputs, externalOutputs } = getExternalPorts(nodes, wires, nodeIds)
+  const inputNames = externalInputs.map(p => p.name)
+  const outputNames = externalOutputs.map(p => p.name)
+  return transformations.filter(t =>
+    arePortMultisetsEqual(inputNames, t.inputPattern) && arePortMultisetsEqual(outputNames, t.outputPattern)
+  )
+}
+
+export const buildTransformationFromDiagram = (
+  nodes: NodeType[],
+  wires: WireType[],
+  diagramName: string
+): TransformationType => {
+  const inputPattern: string[] = []
+  const outputPattern: string[] = []
+
+  nodes.forEach(node => {
+    const inputs = getPortList(node.properties, 'inputs')
+    inputs.forEach((name, idx) => {
+      const hasIncoming = wires.some(w => w.toNodeId === node.id && w.toPortIdx === idx)
+      if (!hasIncoming) inputPattern.push(name)
+    })
+
+    const outputs = getPortList(node.properties, 'outputs')
+    outputs.forEach((name, idx) => {
+      const hasOutgoing = wires.some(w => w.fromNodeId === node.id && w.fromPortIdx === idx)
+      if (!hasOutgoing) outputPattern.push(name)
+    })
+  })
+
+  return {
+    name: diagramName || 'Untitled Transformation',
+    inputPattern,
+    outputPattern,
+    replacementNodes: nodes.map(node => ({ ...node })),
+  }
+}
+
+export const applyTransformationToSelection = (
+  nodes: NodeType[],
+  wires: WireType[],
+  nodeIds: string[],
+  transformation: TransformationType
+) => {
+  if (nodeIds.length === 0) return null
+  const { externalInputs, externalOutputs } = getExternalPorts(nodes, wires, nodeIds)
+  const inputNames = externalInputs.map(p => p.name)
+  const outputNames = externalOutputs.map(p => p.name)
+  if (!arePortMultisetsEqual(inputNames, transformation.inputPattern) || !arePortMultisetsEqual(outputNames, transformation.outputPattern)) {
+    return null
+  }
+
+  const selectedSet = new Set(nodeIds)
+  const selectedNodes = nodes.filter(n => selectedSet.has(n.id))
+  if (selectedNodes.length === 0) return null
+
+  const replacementNodes = transformation.replacementNodes || []
+  if (replacementNodes.length === 0) return null
+
+  const selectedMinX = Math.min(...selectedNodes.map(n => n.x))
+  const selectedMinY = Math.min(...selectedNodes.map(n => n.y))
+  const replacementMinX = Math.min(...replacementNodes.map(n => n.x))
+  const replacementMinY = Math.min(...replacementNodes.map(n => n.y))
+  const deltaX = selectedMinX - replacementMinX
+  const deltaY = selectedMinY - replacementMinY
+
+  const now = Date.now()
+  const idMap: Record<string, string> = {}
+  const remappedReplacementNodes = replacementNodes.map((node, index) => {
+    const newId = `node-${now}-${index}`
+    idMap[node.id] = newId
+    return {
+      ...node,
+      id: newId,
+      x: node.x + deltaX,
+      y: node.y + deltaY,
+    }
+  })
+
+  const remainingNodes = nodes.filter(n => !selectedSet.has(n.id))
+  const remainingWires = wires.filter(w => !selectedSet.has(w.fromNodeId) && !selectedSet.has(w.toNodeId))
+
+  const inputPortMap: Record<string, Array<{ nodeId: string; portIdx: number }>> = {}
+  const outputPortMap: Record<string, Array<{ nodeId: string; portIdx: number }>> = {}
+
+  remappedReplacementNodes.forEach(node => {
+    const inputs = getPortList(node.properties, 'inputs')
+    inputs.forEach((name, idx) => {
+      if (!inputPortMap[name]) inputPortMap[name] = []
+      inputPortMap[name].push({ nodeId: node.id, portIdx: idx })
+    })
+    const outputs = getPortList(node.properties, 'outputs')
+    outputs.forEach((name, idx) => {
+      if (!outputPortMap[name]) outputPortMap[name] = []
+      outputPortMap[name].push({ nodeId: node.id, portIdx: idx })
+    })
+  })
+
+  let wireCounter = 0
+  const nextWireId = () => `wire-${Date.now()}-${wireCounter++}`
+  const newWires: WireType[] = [...remainingWires]
+
+  externalInputs.forEach(input => {
+    const targets = inputPortMap[input.name]
+    if (!targets || targets.length === 0) return
+    const target = targets.shift()!
+    if (input.wire) {
+      newWires.push({
+        id: nextWireId(),
+        fromNodeId: input.wire.fromNodeId,
+        fromPortIdx: input.wire.fromPortIdx,
+        toNodeId: target.nodeId,
+        toPortIdx: target.portIdx,
+      })
+    }
+  })
+
+  externalOutputs.forEach(output => {
+    const sources = outputPortMap[output.name]
+    if (!sources || sources.length === 0) return
+    const source = sources.shift()!
+    output.wires.forEach(wire => {
+      newWires.push({
+        id: nextWireId(),
+        fromNodeId: source.nodeId,
+        fromPortIdx: source.portIdx,
+        toNodeId: wire.toNodeId,
+        toPortIdx: wire.toPortIdx,
+      })
+    })
+  })
+
+  return {
+    nodes: [...remainingNodes, ...remappedReplacementNodes],
+    wires: newWires,
+    selectedNodeIds: remappedReplacementNodes.map(n => n.id),
+    replacementNodes: remappedReplacementNodes,
+  }
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,6 @@
-import { diagramSchema } from '../schemas/diagramSchema';
-import { paletteSchema } from '../schemas/paletteSchema';
+import { diagramSchema } from '../schemas/diagramSchema.ts';
+import { paletteSchema } from '../schemas/paletteSchema.ts';
+import { transformationSchema } from '../schemas/transformationSchema.ts';
 
 // Type for validation errors
 export type ValidationError = {
@@ -238,6 +239,10 @@ export function validateDiagram(data: unknown): ValidationError[] {
 
 export function validatePalette(data: unknown): ValidationError[] {
   return validator.validate(data, paletteSchema);
+}
+
+export function validateTransformation(data: unknown): ValidationError[] {
+  return validator.validate(data, transformationSchema);
 }
 
 // Helper to format validation errors for user display

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@ This comprehensive test suite validates all major functionality of the DxT dataf
 
 ## Test Files
 
-### 1. `validation-test.js`
+### 1. `validation-test.mjs`
 **Purpose:** Tests the JSON schema validation system
 **Coverage:**
 - Valid diagram validation
@@ -65,7 +65,23 @@ This comprehensive test suite validates all major functionality of the DxT dataf
   - Valid data loading
   - Invalid data rejection
 
-### 3. `run-tests.js`
+### 3. `transformation-applicability.test.mjs`
+**Purpose:** Tests transformation applicability logic
+**Coverage:**
+- Applicable transformation detection
+- Internal wire exclusion
+- Unconnected ports treated as external
+- Duplicate port name matching
+
+### 4. `transformation-apply.test.mjs`
+**Purpose:** Tests transformation application and export logic
+**Coverage:**
+- Unwired port export rules
+- Rewiring external connections
+- Duplicate port handling
+- Extra replacement ports remain unconnected
+
+### 5. `run-tests.cjs`
 **Purpose:** Test runner script that executes all test suites
 **Features:**
 - Sequential test execution
@@ -92,8 +108,10 @@ npm run test:app
 ### Direct Execution
 ```bash
 # From project root
-node test/validation-test.cjs
+node --loader ts-node/esm test/validation-test.mjs
 node test/app-functionality.test.cjs
+node --loader ts-node/esm test/transformation-applicability.test.mjs
+node --loader ts-node/esm test/transformation-apply.test.mjs
 node test/run-tests.cjs
 ```
 

--- a/test/app-functionality.test.cjs
+++ b/test/app-functionality.test.cjs
@@ -462,6 +462,21 @@ test('Reject invalid diagram data', () => {
     assertTrue(!hasRequiredNodeFields || !hasCustomNodeDefs || !hasWires);
 });
 
+// === TRANSFORMATION LIBRARY TESTS ===
+console.log('\n🧩 Transformation Library Tests:');
+
+test('Delete transformation removes correct entry', () => {
+    const transformations = [
+        { name: 'T1' },
+        { name: 'T2' },
+        { name: 'T3' }
+    ];
+    const indexToDelete = 1;
+    const updated = transformations.filter((_, i) => i !== indexToDelete);
+    assertEqual(updated.length, 2);
+    assertTrue(updated.every(t => t.name !== 'T2'), 'Deleted transformation should be removed');
+});
+
 // === TEST SUMMARY ===
 console.log('\n' + '='.repeat(50));
 console.log(`📊 Test Results Summary:`);

--- a/test/run-tests.cjs
+++ b/test/run-tests.cjs
@@ -9,7 +9,19 @@ const path = require('path');
 async function runTest(testFile, testName) {
     return new Promise((resolve) => {
         console.log(`📋 Running ${testName}...`);
-        const child = spawn('node', [testFile], { cwd: path.dirname(__filename) });
+        const env = { ...process.env };
+        const args = testFile.endsWith('.mjs')
+            ? ['--loader', 'ts-node/esm', testFile]
+            : [testFile];
+        if (testFile.endsWith('.mjs')) {
+            env.TS_NODE_PROJECT = path.resolve(__dirname, '../tsconfig.app.json');
+            env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+                module: 'ESNext',
+                moduleResolution: 'bundler',
+                allowImportingTsExtensions: true
+            });
+        }
+        const child = spawn('node', args, { cwd: path.dirname(__filename), env });
         
         let output = '';
         child.stdout.on('data', (data) => {
@@ -34,8 +46,10 @@ async function runTest(testFile, testName) {
 
 async function runAllTests() {
     const tests = [
-        { file: 'validation-test.cjs', name: 'Validation System Tests' },
-        { file: 'app-functionality.test.cjs', name: 'Application Functionality Tests' }
+        { file: 'validation-test.mjs', name: 'Validation System Tests' },
+        { file: 'app-functionality.test.cjs', name: 'Application Functionality Tests' },
+        { file: 'transformation-applicability.test.mjs', name: 'Transformation Applicability Tests' },
+        { file: 'transformation-apply.test.mjs', name: 'Transformation Apply Tests' }
     ];
     
     let allPassed = true;

--- a/test/transformation-applicability.test.cjs
+++ b/test/transformation-applicability.test.cjs
@@ -1,0 +1,127 @@
+// Transformation applicability tests
+console.log('=== Transformation Applicability Tests ===\n');
+
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({ module: 'CommonJS' });
+require('ts-node/register/transpile-only');
+
+const { getApplicableTransformations } = require('../src/utils/transformation.ts');
+
+function runTest(testName, testFn) {
+    try {
+        const result = testFn();
+        if (result === true || result === undefined) {
+            console.log(`✅ ${testName}: PASSED`);
+            return true;
+        }
+        console.log(`❌ ${testName}: FAILED - ${result}`);
+        return false;
+    } catch (error) {
+        console.log(`❌ ${testName}: ERROR - ${error.message}`);
+        return false;
+    }
+}
+
+function assertTrue(condition, message = '') {
+    if (!condition) {
+        throw new Error(message || 'Assertion failed');
+    }
+}
+
+let total = 0;
+let passed = 0;
+
+function test(name, fn) {
+    total++;
+    if (runTest(name, fn)) passed++;
+}
+
+const nodes = [
+    {
+        id: 'source-1',
+        type: 'Source',
+        x: 100,
+        y: 100,
+        properties: { name: 'Source', inputs: [], outputs: ['out'] }
+    },
+    {
+        id: 'filter-1',
+        type: 'Filter',
+        x: 300,
+        y: 100,
+        properties: { name: 'Filter', inputs: ['in'], outputs: ['out'] }
+    },
+    {
+        id: 'normalize-1',
+        type: 'Normalize',
+        x: 500,
+        y: 100,
+        properties: { name: 'Normalize', inputs: ['in'], outputs: ['out'] }
+    },
+    {
+        id: 'sink-1',
+        type: 'Sink',
+        x: 700,
+        y: 100,
+        properties: { name: 'Sink', inputs: ['in'], outputs: [] }
+    },
+    {
+        id: 'lonely-1',
+        type: 'Scale',
+        x: 300,
+        y: 260,
+        properties: { name: 'Scale', inputs: ['in'], outputs: ['out'] }
+    }
+];
+
+const wires = [
+    { id: 'wire-1', fromNodeId: 'source-1', fromPortIdx: 0, toNodeId: 'filter-1', toPortIdx: 0 },
+    { id: 'wire-2', fromNodeId: 'filter-1', fromPortIdx: 0, toNodeId: 'normalize-1', toPortIdx: 0 },
+    { id: 'wire-3', fromNodeId: 'normalize-1', fromPortIdx: 0, toNodeId: 'sink-1', toPortIdx: 0 }
+];
+
+const transformations = [
+    {
+        name: 'Filter + Normalize -> OptimizedFilter',
+        inputPattern: ['in'],
+        outputPattern: ['out'],
+        replacementNodes: []
+    },
+    {
+        name: 'Mismatched Output',
+        inputPattern: ['in'],
+        outputPattern: ['result'],
+        replacementNodes: []
+    },
+    {
+        name: 'Double Input Needed',
+        inputPattern: ['in', 'in'],
+        outputPattern: ['out'],
+        replacementNodes: []
+    }
+];
+
+console.log('🔁 Applicability Matching:');
+
+test('Transformation matches external ports of selection', () => {
+    const selection = ['filter-1', 'normalize-1'];
+    const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
+    assertTrue(applicable.some(t => t.name === 'Filter + Normalize -> OptimizedFilter'), 'Expected applicable transform');
+    assertTrue(!applicable.some(t => t.name === 'Mismatched Output'), 'Did not expect mismatched output transform');
+});
+
+test('Internal wires are ignored when computing external ports', () => {
+    const selection = ['filter-1', 'normalize-1'];
+    const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
+    assertTrue(!applicable.some(t => t.name === 'Double Input Needed'), 'Internal port should not count as external');
+});
+
+test('Unconnected ports are treated as external', () => {
+    const selection = ['lonely-1'];
+    const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
+    assertTrue(applicable.some(t => t.name === 'Filter + Normalize -> OptimizedFilter'), 'Unconnected ports should still match');
+});
+
+console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
+if (passed !== total) {
+    process.exitCode = 1;
+}

--- a/test/transformation-applicability.test.mjs
+++ b/test/transformation-applicability.test.mjs
@@ -1,0 +1,146 @@
+// Transformation applicability tests
+console.log('=== Transformation Applicability Tests ===\n');
+
+import { getApplicableTransformations } from '../src/utils/transformation.ts';
+
+function runTest(testName, testFn) {
+  try {
+    const result = testFn();
+    if (result === true || result === undefined) {
+      console.log(`✅ ${testName}: PASSED`);
+      return true;
+    }
+    console.log(`❌ ${testName}: FAILED - ${result}`);
+    return false;
+  } catch (error) {
+    console.log(`❌ ${testName}: ERROR - ${error.message}`);
+    return false;
+  }
+}
+
+function assertTrue(condition, message = '') {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}
+
+let total = 0;
+let passed = 0;
+
+function test(name, fn) {
+  total++;
+  if (runTest(name, fn)) passed++;
+}
+
+const nodes = [
+  {
+    id: 'source-1',
+    type: 'Source',
+    x: 100,
+    y: 100,
+    properties: { name: 'Source', inputs: [], outputs: ['out'] }
+  },
+  {
+    id: 'filter-1',
+    type: 'Filter',
+    x: 300,
+    y: 100,
+    properties: { name: 'Filter', inputs: ['in'], outputs: ['out'] }
+  },
+  {
+    id: 'normalize-1',
+    type: 'Normalize',
+    x: 500,
+    y: 100,
+    properties: { name: 'Normalize', inputs: ['in'], outputs: ['out'] }
+  },
+  {
+    id: 'sink-1',
+    type: 'Sink',
+    x: 700,
+    y: 100,
+    properties: { name: 'Sink', inputs: ['in'], outputs: [] }
+  },
+  {
+    id: 'lonely-1',
+    type: 'Scale',
+    x: 300,
+    y: 260,
+    properties: { name: 'Scale', inputs: ['in'], outputs: ['out'] }
+  }
+];
+
+const wires = [
+  { id: 'wire-1', fromNodeId: 'source-1', fromPortIdx: 0, toNodeId: 'filter-1', toPortIdx: 0 },
+  { id: 'wire-2', fromNodeId: 'filter-1', fromPortIdx: 0, toNodeId: 'normalize-1', toPortIdx: 0 },
+  { id: 'wire-3', fromNodeId: 'normalize-1', fromPortIdx: 0, toNodeId: 'sink-1', toPortIdx: 0 }
+];
+
+const transformations = [
+  {
+    name: 'Filter + Normalize -> OptimizedFilter',
+    inputPattern: ['in'],
+    outputPattern: ['out'],
+    replacementNodes: []
+  },
+  {
+    name: 'Mismatched Output',
+    inputPattern: ['in'],
+    outputPattern: ['result'],
+    replacementNodes: []
+  },
+  {
+    name: 'Double Input Needed',
+    inputPattern: ['in', 'in'],
+    outputPattern: ['out'],
+    replacementNodes: []
+  }
+];
+
+console.log('🔁 Applicability Matching:');
+
+test('Transformation matches external ports of selection', () => {
+  const selection = ['filter-1', 'normalize-1'];
+  const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
+  assertTrue(applicable.some(t => t.name === 'Filter + Normalize -> OptimizedFilter'), 'Expected applicable transform');
+  assertTrue(!applicable.some(t => t.name === 'Mismatched Output'), 'Did not expect mismatched output transform');
+});
+
+test('Internal wires are ignored when computing external ports', () => {
+  const selection = ['filter-1', 'normalize-1'];
+  const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
+  assertTrue(!applicable.some(t => t.name === 'Double Input Needed'), 'Internal port should not count as external');
+});
+
+test('Unconnected ports are treated as external', () => {
+  const selection = ['lonely-1'];
+  const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
+  assertTrue(applicable.some(t => t.name === 'Filter + Normalize -> OptimizedFilter'), 'Unconnected ports should still match');
+});
+
+test('Duplicate port names are matched as a multiset', () => {
+  const localNodes = [
+    { id: 'src-a', type: 'Source', x: 50, y: 50, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
+    { id: 'src-b', type: 'Source', x: 50, y: 120, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
+    { id: 'proc-a', type: 'Proc', x: 220, y: 50, properties: { name: 'Proc', inputs: ['in'], outputs: ['out'] } },
+    { id: 'proc-b', type: 'Proc', x: 220, y: 120, properties: { name: 'Proc', inputs: ['in'], outputs: ['out'] } },
+    { id: 'sink', type: 'Sink', x: 420, y: 85, properties: { name: 'Sink', inputs: ['in'], outputs: [] } }
+  ];
+  const localWires = [
+    { id: 'w1', fromNodeId: 'src-a', fromPortIdx: 0, toNodeId: 'proc-a', toPortIdx: 0 },
+    { id: 'w2', fromNodeId: 'src-b', fromPortIdx: 0, toNodeId: 'proc-b', toPortIdx: 0 },
+    { id: 'w3', fromNodeId: 'proc-a', fromPortIdx: 0, toNodeId: 'sink', toPortIdx: 0 },
+    { id: 'w4', fromNodeId: 'proc-b', fromPortIdx: 0, toNodeId: 'sink', toPortIdx: 0 }
+  ];
+  const localTransforms = [
+    { name: 'Two In, One Out', inputPattern: ['in', 'in'], outputPattern: ['out', 'out'], replacementNodes: [] }
+  ];
+  const selection = ['proc-a', 'proc-b'];
+  const applicable = getApplicableTransformations(localNodes, localWires, selection, localTransforms);
+  assertTrue(applicable.length === 1, 'Expected multiset match for duplicate ports');
+});
+
+console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
+if (passed !== total) {
+  process.exitCode = 1;
+}

--- a/test/transformation-apply.test.mjs
+++ b/test/transformation-apply.test.mjs
@@ -1,0 +1,160 @@
+// Transformation apply and export tests
+console.log('=== Transformation Apply Tests ===\n');
+
+import { applyTransformationToSelection, buildTransformationFromDiagram } from '../src/utils/transformation.ts';
+
+function runTest(testName, testFn) {
+  try {
+    const result = testFn();
+    if (result === true || result === undefined) {
+      console.log(`✅ ${testName}: PASSED`);
+      return true;
+    }
+    console.log(`❌ ${testName}: FAILED - ${result}`);
+    return false;
+  } catch (error) {
+    console.log(`❌ ${testName}: ERROR - ${error.message}`);
+    return false;
+  }
+}
+
+function assertTrue(condition, message = '') {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}
+
+function assertEqual(actual, expected, message = '') {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}. ${message}`);
+  }
+}
+
+let total = 0;
+let passed = 0;
+
+function test(name, fn) {
+  total++;
+  if (runTest(name, fn)) passed++;
+}
+
+console.log('🧪 Transformation Export:');
+
+test('Unwired ports become transformation patterns', () => {
+  const nodes = [
+    {
+      id: 'node-a',
+      type: 'A',
+      x: 100,
+      y: 100,
+      properties: { name: 'A', inputs: ['in1', 'in2'], outputs: ['out1'] }
+    },
+    {
+      id: 'node-b',
+      type: 'B',
+      x: 300,
+      y: 100,
+      properties: { name: 'B', inputs: ['in'], outputs: ['out'] }
+    }
+  ];
+  const wires = [
+    { id: 'wire-1', fromNodeId: 'node-a', fromPortIdx: 0, toNodeId: 'node-b', toPortIdx: 0 }
+  ];
+  const transformation = buildTransformationFromDiagram(nodes, wires, 'My Diagram');
+  assertEqual(transformation.name, 'My Diagram');
+  assertEqual(transformation.inputPattern.sort(), ['in1', 'in2']);
+  assertEqual(transformation.outputPattern, ['out']);
+  assertTrue(transformation.replacementNodes.length === 2, 'Expected nodes to be included');
+});
+
+console.log('\n🔁 Transformation Apply:');
+
+test('Apply transformation rewires external connections', () => {
+  const nodes = [
+    { id: 'source', type: 'Source', x: 50, y: 100, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
+    { id: 'a', type: 'A', x: 200, y: 100, properties: { name: 'A', inputs: ['in'], outputs: ['out'] } },
+    { id: 'b', type: 'B', x: 350, y: 100, properties: { name: 'B', inputs: ['in'], outputs: ['out'] } },
+    { id: 'sink', type: 'Sink', x: 500, y: 100, properties: { name: 'Sink', inputs: ['in'], outputs: [] } }
+  ];
+  const wires = [
+    { id: 'w1', fromNodeId: 'source', fromPortIdx: 0, toNodeId: 'a', toPortIdx: 0 },
+    { id: 'w2', fromNodeId: 'a', fromPortIdx: 0, toNodeId: 'b', toPortIdx: 0 },
+    { id: 'w3', fromNodeId: 'b', fromPortIdx: 0, toNodeId: 'sink', toPortIdx: 0 }
+  ];
+  const transformation = {
+    name: 'Replace A+B',
+    inputPattern: ['in'],
+    outputPattern: ['out'],
+    replacementNodes: [
+      { id: 'r1', type: 'Optimized', x: 200, y: 100, properties: { name: 'Optimized', inputs: ['in'], outputs: ['out'] } }
+    ]
+  };
+
+  const result = applyTransformationToSelection(nodes, wires, ['a', 'b'], transformation);
+  assertTrue(result !== null, 'Expected transformation to apply');
+  assertTrue(result.nodes.length === 3, 'Expected 3 nodes after replacement');
+  assertTrue(result.wires.length === 2, 'Expected 2 wires after replacement');
+
+  const wireFromSource = result.wires.find(w => w.fromNodeId === 'source');
+  const wireToSink = result.wires.find(w => w.toNodeId === 'sink');
+  assertTrue(!!wireFromSource, 'Expected wire from source');
+  assertTrue(!!wireToSink, 'Expected wire to sink');
+});
+
+test('Apply transformation supports duplicate port names', () => {
+  const nodes = [
+    { id: 'src1', type: 'Source', x: 50, y: 50, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
+    { id: 'src2', type: 'Source', x: 50, y: 120, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
+    { id: 'p1', type: 'Proc', x: 200, y: 50, properties: { name: 'Proc', inputs: ['in'], outputs: ['out'] } },
+    { id: 'p2', type: 'Proc', x: 200, y: 120, properties: { name: 'Proc', inputs: ['in'], outputs: ['out'] } },
+    { id: 'sink1', type: 'Sink', x: 400, y: 50, properties: { name: 'Sink', inputs: ['in'], outputs: [] } },
+    { id: 'sink2', type: 'Sink', x: 400, y: 120, properties: { name: 'Sink', inputs: ['in'], outputs: [] } }
+  ];
+  const wires = [
+    { id: 'w1', fromNodeId: 'src1', fromPortIdx: 0, toNodeId: 'p1', toPortIdx: 0 },
+    { id: 'w2', fromNodeId: 'src2', fromPortIdx: 0, toNodeId: 'p2', toPortIdx: 0 },
+    { id: 'w3', fromNodeId: 'p1', fromPortIdx: 0, toNodeId: 'sink1', toPortIdx: 0 },
+    { id: 'w4', fromNodeId: 'p2', fromPortIdx: 0, toNodeId: 'sink2', toPortIdx: 0 }
+  ];
+  const transformation = {
+    name: 'Merge Proc',
+    inputPattern: ['in', 'in'],
+    outputPattern: ['out', 'out'],
+    replacementNodes: [
+      { id: 'r1', type: 'Merged', x: 200, y: 80, properties: { name: 'Merged', inputs: ['in', 'in'], outputs: ['out', 'out'] } }
+    ]
+  };
+
+  const result = applyTransformationToSelection(nodes, wires, ['p1', 'p2'], transformation);
+  assertTrue(result !== null, 'Expected transformation to apply');
+  assertTrue(result.wires.length === 4, 'Expected four external wires after replacement');
+});
+
+test('Unmatched replacement ports remain unconnected', () => {
+  const nodes = [
+    { id: 'src', type: 'Source', x: 50, y: 100, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
+    { id: 'proc', type: 'Proc', x: 200, y: 100, properties: { name: 'Proc', inputs: ['in'], outputs: ['out'] } },
+    { id: 'sink', type: 'Sink', x: 350, y: 100, properties: { name: 'Sink', inputs: ['in'], outputs: [] } }
+  ];
+  const wires = [
+    { id: 'w1', fromNodeId: 'src', fromPortIdx: 0, toNodeId: 'proc', toPortIdx: 0 },
+    { id: 'w2', fromNodeId: 'proc', fromPortIdx: 0, toNodeId: 'sink', toPortIdx: 0 }
+  ];
+  const transformation = {
+    name: 'Proc+Extra',
+    inputPattern: ['in'],
+    outputPattern: ['out'],
+    replacementNodes: [
+      { id: 'r1', type: 'ProcPlus', x: 200, y: 100, properties: { name: 'ProcPlus', inputs: ['in'], outputs: ['out', 'extra'] } }
+    ]
+  };
+
+  const result = applyTransformationToSelection(nodes, wires, ['proc'], transformation);
+  assertTrue(result !== null, 'Expected transformation to apply');
+  assertTrue(result.wires.length === 2, 'Expected only existing external wires to be rewired');
+});
+
+console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
+if (passed !== total) {
+  process.exitCode = 1;
+}

--- a/test/transformation-apply.test.mjs
+++ b/test/transformation-apply.test.mjs
@@ -62,7 +62,7 @@ test('Unwired ports become transformation patterns', () => {
   ];
   const transformation = buildTransformationFromDiagram(nodes, wires, 'My Diagram');
   assertEqual(transformation.name, 'My Diagram');
-  assertEqual(transformation.inputPattern.sort(), ['in1', 'in2']);
+  assertEqual([...transformation.inputPattern].sort(), ['in1', 'in2'].sort());
   assertEqual(transformation.outputPattern, ['out']);
   assertTrue(transformation.replacementNodes.length === 2, 'Expected nodes to be included');
 });

--- a/test/validation-test.cjs
+++ b/test/validation-test.cjs
@@ -1,46 +1,40 @@
-// Simple validation test runner
+// JSON Schema Validation Tests (real schema validation)
 console.log('=== JSON Schema Validation Tests ===\n');
 
-// Mock validation functions for testing (since we can't easily import the ES modules)
-function mockValidateSchema(data, schema) {
-    const errors = [];
-    
-    // Basic validation logic for testing
-    if (schema.required) {
-        for (const field of schema.required) {
-            if (!(field in data)) {
-                errors.push({ path: field, message: `Missing required field: ${field}` });
-            }
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({ module: 'CommonJS' });
+require('ts-node/register/transpile-only');
+
+const { validateDiagram, validatePalette, validateTransformation } = require('../src/utils/validation.ts');
+
+function runTest(testName, testFn) {
+    try {
+        const result = testFn();
+        if (result === true || result === undefined) {
+            console.log(`✅ ${testName}: PASSED`);
+            return true;
         }
+        console.log(`❌ ${testName}: FAILED - ${result}`);
+        return false;
+    } catch (error) {
+        console.log(`❌ ${testName}: ERROR - ${error.message}`);
+        return false;
     }
-    
-    if (schema.properties) {
-        for (const [key, prop] of Object.entries(schema.properties)) {
-            if (key in data) {
-                if (prop.type === 'array' && !Array.isArray(data[key])) {
-                    errors.push({ path: key, message: `Expected array for field: ${key}` });
-                }
-                if (prop.type === 'string' && typeof data[key] !== 'string') {
-                    errors.push({ path: key, message: `Expected string for field: ${key}` });
-                }
-                if (prop.type === 'number' && typeof data[key] !== 'number') {
-                    errors.push({ path: key, message: `Expected number for field: ${key}` });
-                }
-                if (prop.type === 'object' && typeof data[key] !== 'object') {
-                    errors.push({ path: key, message: `Expected object for field: ${key}` });
-                }
-            }
-        }
-    }
-    
-    return errors;
 }
 
-function formatValidationErrors(errors) {
-    return errors.map(err => `• ${err.path}: ${err.message}`).join('\n');
+function assertTrue(condition, message = '') {
+    if (!condition) {
+        throw new Error(message || 'Assertion failed');
+    }
 }
 
-// Test valid diagram
+let total = 0;
+let passed = 0;
+
+function test(name, fn) {
+    total++;
+    if (runTest(name, fn)) passed++;
+}
+
 const validDiagram = {
     name: "Test Diagram",
     nodes: [
@@ -74,23 +68,19 @@ const validDiagram = {
     ]
 };
 
-// Test invalid diagram (missing required fields)
 const invalidDiagram = {
     name: "Test Diagram",
     nodes: [
         {
             id: "node1",
             type: "Source",
-            // Missing x, y coordinates
             properties: {
                 name: "Source Node"
             }
         }
     ]
-    // Missing customNodeDefs and wires
 };
 
-// Test valid palette
 const validPalette = [
     {
         name: "CustomNode1",
@@ -104,91 +94,77 @@ const validPalette = [
     }
 ];
 
-// Test invalid palette
 const invalidPalette = [
     {
         name: "CustomNode1",
-        inputs: ["input1"],
-        // Missing outputs field
+        inputs: ["input1"]
     },
     {
-        // Missing name field
         inputs: [],
         outputs: ["result"]
     }
 ];
 
-// Basic schemas for testing
-const diagramSchema = {
-    required: ['name', 'nodes', 'customNodeDefs', 'wires'],
-    properties: {
-        name: { type: 'string' },
-        nodes: { type: 'array' },
-        customNodeDefs: { type: 'array' },
-        wires: { type: 'array' }
-    }
+const validTransformation = {
+    name: "Sample Transform",
+    inputPattern: ["in"],
+    outputPattern: ["out"],
+    replacementNodes: [
+        {
+            id: "node1",
+            type: "OptimizedFilter",
+            x: 100,
+            y: 100,
+            properties: {
+                name: "OptimizedFilter",
+                inputs: ["in"],
+                outputs: ["out"]
+            }
+        }
+    ]
 };
 
-const paletteSchema = {
-    type: 'array'
+const invalidTransformation = {
+    name: "Bad Transform",
+    inputPattern: "in",
+    replacementNodes: []
 };
 
-// Run tests
-console.log('1. Testing Valid Diagram:');
-const validDiagramErrors = mockValidateSchema(validDiagram, diagramSchema);
-if (validDiagramErrors.length === 0) {
-    console.log('✅ PASSED: No validation errors\n');
-} else {
-    console.log('❌ FAILED: Unexpected errors:', formatValidationErrors(validDiagramErrors), '\n');
-}
+console.log('🔎 Diagram Schema Validation:');
+test('Valid diagram passes validation', () => {
+    const errors = validateDiagram(validDiagram);
+    assertTrue(errors.length === 0, 'Expected no validation errors');
+});
 
-console.log('2. Testing Invalid Diagram:');
-const invalidDiagramErrors = mockValidateSchema(invalidDiagram, diagramSchema);
-if (invalidDiagramErrors.length > 0) {
-    console.log('✅ PASSED: Found validation errors:');
-    console.log(formatValidationErrors(invalidDiagramErrors), '\n');
-} else {
-    console.log('❌ FAILED: Should have found errors\n');
-}
+test('Invalid diagram fails validation', () => {
+    const errors = validateDiagram(invalidDiagram);
+    assertTrue(errors.length > 0, 'Expected validation errors');
+});
 
-console.log('3. Testing Valid Palette:');
-const validPaletteErrors = [];
-if (Array.isArray(validPalette)) {
-    for (const item of validPalette) {
-        if (!item.name || !item.inputs || !item.outputs) {
-            validPaletteErrors.push({ path: 'palette item', message: 'Missing required fields' });
-        }
-    }
-}
-if (validPaletteErrors.length === 0) {
-    console.log('✅ PASSED: No validation errors\n');
-} else {
-    console.log('❌ FAILED: Unexpected errors:', formatValidationErrors(validPaletteErrors), '\n');
-}
+console.log('\n🎨 Palette Schema Validation:');
+test('Valid palette passes validation', () => {
+    const errors = validatePalette(validPalette);
+    assertTrue(errors.length === 0, 'Expected no validation errors');
+});
 
-console.log('4. Testing Invalid Palette:');
-const invalidPaletteErrors = [];
-if (Array.isArray(invalidPalette)) {
-    for (let i = 0; i < invalidPalette.length; i++) {
-        const item = invalidPalette[i];
-        if (!item.name) {
-            invalidPaletteErrors.push({ path: `item[${i}].name`, message: 'Missing required field: name' });
-        }
-        if (!item.outputs) {
-            invalidPaletteErrors.push({ path: `item[${i}].outputs`, message: 'Missing required field: outputs' });
-        }
-    }
-}
-if (invalidPaletteErrors.length > 0) {
-    console.log('✅ PASSED: Found validation errors:');
-    console.log(formatValidationErrors(invalidPaletteErrors), '\n');
-} else {
-    console.log('❌ FAILED: Should have found errors\n');
-}
+test('Invalid palette fails validation', () => {
+    const errors = validatePalette(invalidPalette);
+    assertTrue(errors.length > 0, 'Expected validation errors');
+});
 
-console.log('=== Test Summary ===');
-console.log('These tests verify that the validation logic works correctly.');
-console.log('The actual validation system in your app uses comprehensive JSON schemas');
-console.log('defined in src/schemas/ and utilities in src/utils/validation.ts');
-console.log('\nTo test the real validation system, use the main application');
-console.log('and try loading invalid diagram or palette files.');
+console.log('\n🔁 Transformation Schema Validation:');
+test('Valid transformation passes validation', () => {
+    const errors = validateTransformation(validTransformation);
+    assertTrue(errors.length === 0, 'Expected no validation errors');
+});
+
+test('Invalid transformation fails validation', () => {
+    const errors = validateTransformation(invalidTransformation);
+    assertTrue(errors.length > 0, 'Expected validation errors');
+});
+
+console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
+
+if (passed !== total) {
+    process.exitCode = 1;
+}

--- a/test/validation-test.mjs
+++ b/test/validation-test.mjs
@@ -1,0 +1,214 @@
+// JSON Schema Validation Tests (real schema validation)
+console.log('=== JSON Schema Validation Tests ===\n');
+
+import { validateDiagram, validatePalette, validateTransformation } from '../src/utils/validation.ts';
+
+function runTest(testName, testFn) {
+  try {
+    const result = testFn();
+    if (result === true || result === undefined) {
+      console.log(`✅ ${testName}: PASSED`);
+      return true;
+    }
+    console.log(`❌ ${testName}: FAILED - ${result}`);
+    return false;
+  } catch (error) {
+    console.log(`❌ ${testName}: ERROR - ${error.message}`);
+    return false;
+  }
+}
+
+function assertTrue(condition, message = '') {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}
+
+let total = 0;
+let passed = 0;
+
+function test(name, fn) {
+  total++;
+  if (runTest(name, fn)) passed++;
+}
+
+const validDiagram = {
+  name: "Test Diagram",
+  nodes: [
+    {
+      id: "node1",
+      type: "Source",
+      x: 100,
+      y: 100,
+      properties: {
+        name: "Source Node",
+        inputs: [],
+        outputs: ["out"]
+      }
+    }
+  ],
+  customNodeDefs: [
+    {
+      name: "CustomNode",
+      inputs: ["in1", "in2"],
+      outputs: ["out1"]
+    }
+  ],
+  wires: [
+    {
+      id: "wire1",
+      fromNodeId: "node1",
+      fromPortIdx: 0,
+      toNodeId: "node2",
+      toPortIdx: 0
+    }
+  ]
+};
+
+const invalidDiagram = {
+  name: "Test Diagram",
+  nodes: [
+    {
+      id: "node1",
+      type: "Source",
+      properties: {
+        name: "Source Node"
+      }
+    }
+  ]
+};
+
+const validPalette = [
+  {
+    name: "CustomNode1",
+    inputs: ["input1", "input2"],
+    outputs: ["output1"]
+  },
+  {
+    name: "CustomNode2",
+    inputs: [],
+    outputs: ["result"]
+  }
+];
+
+const invalidPalette = [
+  {
+    name: "CustomNode1",
+    inputs: ["input1"]
+  },
+  {
+    inputs: [],
+    outputs: ["result"]
+  }
+];
+
+const validTransformation = {
+  name: "Sample Transform",
+  inputPattern: ["in"],
+  outputPattern: ["out"],
+  replacementNodes: [
+    {
+      id: "node1",
+      type: "OptimizedFilter",
+      x: 100,
+      y: 100,
+      properties: {
+        name: "OptimizedFilter",
+        inputs: ["in"],
+        outputs: ["out"]
+      }
+    }
+  ]
+};
+
+const invalidTransformation = {
+  name: "Bad Transform",
+  inputPattern: "in",
+  replacementNodes: []
+};
+
+console.log('🔎 Diagram Schema Validation:');
+test('Valid diagram passes validation', () => {
+  const errors = validateDiagram(validDiagram);
+  assertTrue(errors.length === 0, 'Expected no validation errors');
+});
+
+test('Invalid diagram fails validation', () => {
+  const errors = validateDiagram(invalidDiagram);
+  assertTrue(errors.length > 0, 'Expected validation errors');
+});
+
+console.log('\n🎨 Palette Schema Validation:');
+test('Valid palette passes validation', () => {
+  const errors = validatePalette(validPalette);
+  assertTrue(errors.length === 0, 'Expected no validation errors');
+});
+
+test('Invalid palette fails validation', () => {
+  const errors = validatePalette(invalidPalette);
+  assertTrue(errors.length > 0, 'Expected validation errors');
+});
+
+console.log('\n🔁 Transformation Schema Validation:');
+test('Valid transformation passes validation', () => {
+  const errors = validateTransformation(validTransformation);
+  assertTrue(errors.length === 0, 'Expected no validation errors');
+});
+
+test('Invalid transformation fails validation', () => {
+  const errors = validateTransformation(invalidTransformation);
+  assertTrue(errors.length > 0, 'Expected validation errors');
+});
+
+console.log('\n🧩 Schema Edge Cases:');
+test('Empty port arrays are allowed', () => {
+  const diagram = {
+    name: 'Empty Ports',
+    nodes: [
+      {
+        id: 'node1',
+        type: 'Empty',
+        x: 0,
+        y: 0,
+        properties: { name: 'Empty', inputs: [], outputs: [] }
+      }
+    ],
+    customNodeDefs: [],
+    wires: []
+  };
+  const errors = validateDiagram(diagram);
+  assertTrue(errors.length === 0, 'Expected empty port arrays to be valid');
+});
+
+test('Invalid port name fails validation', () => {
+  const badPalette = [
+    { name: 'BadPort', inputs: [''], outputs: ['out'] }
+  ];
+  const errors = validatePalette(badPalette);
+  assertTrue(errors.length > 0, 'Expected invalid port name error');
+});
+
+test('Node properties must be an object', () => {
+  const diagram = {
+    name: 'Bad Properties',
+    nodes: [
+      {
+        id: 'node1',
+        type: 'Bad',
+        x: 0,
+        y: 0,
+        properties: 'not-an-object'
+      }
+    ],
+    customNodeDefs: [],
+    wires: []
+  };
+  const errors = validateDiagram(diagram);
+  assertTrue(errors.length > 0, 'Expected invalid properties error');
+});
+
+console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
+
+if (passed !== total) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
- Introduced a sample transformation diagram in `samples/diagram.json`.
- Added a palette definition in `samples/palette.json` with new node types.
- Created a transformation definition in `samples/transformation.json` for optimized filtering.
- Implemented a JSON schema for transformation files in `src/schemas/transformationSchema.ts`.
- Developed utility functions for handling transformations in `src/utils/transformation.ts`.
- Added tests for transformation applicability and application in `test/transformation-applicability.test.mjs` and `test/transformation-apply.test.mjs`.
- Implemented JSON schema validation tests for diagrams, palettes, and transformations in `test/validation-test.mjs`.