### PR TITLE
refactor: migrate tests to Vitest and update test structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "ts-node": "^10.9.2",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1041,9 +1042,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -1791,6 +1792,92 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1874,6 +1961,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1938,6 +2035,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1969,6 +2076,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1984,6 +2108,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -2067,6 +2201,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2090,6 +2234,13 @@
       "integrity": "sha512-scWpzXEJEMrGJa4Y6m/tVotb0WuvNmasv3wWVzUAeCgKU0ToFOhUW6Z+xWnRQANMYGxN4ngJXIThgBJOqzVPCQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -2323,6 +2474,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2331,6 +2492,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2717,6 +2888,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2725,6 +2903,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-error": {
@@ -2892,6 +3080,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3139,6 +3344,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3148,6 +3360,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3174,6 +3400,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -3218,6 +3458,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3470,6 +3740,519 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -3498,6 +4281,589 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3512,6 +4878,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node test/run-tests.cjs",
-    "test:validation": "node test/validation-test.cjs",
-    "test:app": "node test/app-functionality.test.cjs"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:validation": "vitest run test/validation-test.cjs",
+    "test:app": "vitest run test/app-functionality.test.cjs"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -29,6 +30,7 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^2.1.9"
   }
 }

--- a/test/app-functionality.test.cjs
+++ b/test/app-functionality.test.cjs
@@ -1,35 +1,13 @@
-// Comprehensive test suite for DxT application functionality
-console.log('=== DxT Application Functionality Tests ===\n');
+const fs = require('node:fs');
+const path = require('node:path');
 
-const fs = require('fs');
-const path = require('path');
-
-// Test utilities
-function runTest(testName, testFn) {
-    try {
-        const result = testFn();
-        if (result === true || result === undefined) {
-            console.log(`✅ ${testName}: PASSED`);
-            return true;
-        } else {
-            console.log(`❌ ${testName}: FAILED - ${result}`);
-            return false;
-        }
-    } catch (error) {
-        console.log(`❌ ${testName}: ERROR - ${error.message}`);
-        return false;
-    }
-}
-
-function assertEqual(actual, expected, message = '') {
-    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}. ${message}`);
-    }
+function assertEqual(actual, expected) {
+    expect(actual).toEqual(expected);
 }
 
 function assertTrue(condition, message = '') {
     if (!condition) {
-        throw new Error(`Assertion failed: ${message}`);
+        throw new Error(message || 'Assertion failed');
     }
 }
 
@@ -56,19 +34,7 @@ const createMockNodeDef = (name, inputs, outputs) => ({
     outputs
 });
 
-// Test counters
-let totalTests = 0;
-let passedTests = 0;
-
-function test(name, fn) {
-    totalTests++;
-    if (runTest(name, fn)) {
-        passedTests++;
-    }
-}
-
 // === NODE MANAGEMENT TESTS ===
-console.log('📦 Node Management Tests:');
 
 test('Create node with valid properties', () => {
     const node = createMockNode('node1', 'Source', 50, 75);
@@ -108,7 +74,6 @@ test('Node property updates preserve other properties', () => {
 });
 
 // === WIRE MANAGEMENT TESTS ===
-console.log('\n🔌 Wire Management Tests:');
 
 test('Create valid wire connection', () => {
     const wire = createMockWire('wire1', 'source1', 0, 'sink1', 0);
@@ -254,7 +219,6 @@ test('Undo-triggered wire redraw uses post-layout rerender', () => {
 });
 
 // === CUSTOM NODE DEFINITIONS TESTS ===
-console.log('\n🏗️  Custom Node Definition Tests:');
 
 test('Create custom node definition', () => {
     const customDef = createMockNodeDef('ProcessorNode', ['input1', 'input2'], ['output1', 'output2']);
@@ -286,7 +250,6 @@ test('Built-in node definitions are preserved', () => {
 });
 
 // === PALETTE SAVE FUNCTIONALITY TESTS ===
-console.log('\n🎨 Palette Save Functionality Tests:');
 
 test('Palette save modal state initialization', () => {
     // Simulate initial state
@@ -312,7 +275,6 @@ test('Palette save filename with user input', () => {
 });
 
 // === HEADER BRANDING TESTS ===
-console.log('\n🧭 Header Branding Tests:');
 
 test('Branding bar includes logo and title', () => {
     const appPath = path.resolve(__dirname, '../src/App.tsx');
@@ -395,7 +357,6 @@ test('Palette data structure for save', () => {
 });
 
 // === SELECTION MANAGEMENT TESTS ===
-console.log('\n🎯 Selection Management Tests:');
 
 test('Single node selection', () => {
     let selectedNodeIds = [];
@@ -449,7 +410,6 @@ test('Lasso selection area', () => {
 });
 
 // === COPY/PASTE FUNCTIONALITY TESTS ===
-console.log('\n📋 Copy/Paste Functionality Tests:');
 
 test('Copy selected nodes to clipboard', () => {
     const nodes = [
@@ -510,7 +470,6 @@ test('Paste preserves wires between copied nodes', () => {
 });
 
 // === FILE FORMAT TESTS ===
-console.log('\n💾 File Format Tests:');
 
 test('Diagram save format structure', () => {
     const saveData = {
@@ -562,7 +521,6 @@ test('Diagram load uses file picker with fallback', () => {
 });
 
 // === NODE DELETION TESTS ===
-console.log('\n🗑️  Node Deletion Tests:');
 
 test('Delete selected nodes', () => {
     const nodes = [
@@ -596,7 +554,6 @@ test('Delete nodes removes connected wires', () => {
 });
 
 // === CANVAS INTERACTION TESTS ===
-console.log('\n🖱️  Canvas Interaction Tests:');
 
 test('Canvas drop zone validation', () => {
     const canvasRect = { left: 300, top: 48, width: 800, height: 600 };
@@ -622,7 +579,6 @@ test('Context menu positioning', () => {
 });
 
 // === PROPERTY EDITOR TESTS ===
-console.log('\n⚙️  Property Editor Tests:');
 
 test('Property editor data binding', () => {
     const node = createMockNode('node1', 'Source');
@@ -659,7 +615,6 @@ test('Property updates merge correctly', () => {
 });
 
 // === VALIDATION INTEGRATION TESTS ===
-console.log('\n🔍 Validation Integration Tests:');
 
 test('Load valid diagram data', () => {
     const validDiagramData = {
@@ -696,7 +651,6 @@ test('Reject invalid diagram data', () => {
 });
 
 // === TRANSFORMATION LIBRARY TESTS ===
-console.log('\n🧩 Transformation Library Tests:');
 
 test('Delete transformation removes correct entry', () => {
     const transformations = [
@@ -711,7 +665,6 @@ test('Delete transformation removes correct entry', () => {
 });
 
 // === CANVAS SCROLLING TESTS ===
-console.log('\n📜 Canvas Scrolling Tests:');
 
 test('Wire rendering accounts for canvas scroll offsets', () => {
     const canvasPath = path.resolve(__dirname, '../src/components/Canvas.tsx');
@@ -847,33 +800,3 @@ test('Canvas scroll triggers when content exceeds viewport', () => {
 });
 
 // === TEST SUMMARY ===
-console.log('\n' + '='.repeat(50));
-console.log(`📊 Test Results Summary:`);
-console.log(`Total Tests: ${totalTests}`);
-console.log(`Passed: ${passedTests}`);
-console.log(`Failed: ${totalTests - passedTests}`);
-console.log(`Success Rate: ${((passedTests / totalTests) * 100).toFixed(1)}%`);
-
-if (passedTests === totalTests) {
-    console.log('\n🎉 All tests passed! Your DxT application functionality is working correctly.');
-} else {
-    console.log('\n⚠️  Some tests failed. Please review the failing functionality.');
-}
-
-console.log('\n📝 Test Coverage Areas:');
-console.log('✅ Node Management (creation, updates, positioning)');
-console.log('✅ Wire Management (connections, validation, removal)');
-console.log('✅ Custom Node Definitions (creation, validation)');
-console.log('✅ Palette Save Functionality (modal, filename handling, state management)');
-console.log('✅ Selection Management (single, multi, lasso, clearing)');
-console.log('✅ Copy/Paste Functionality (clipboard, offset, wire preservation)');
-console.log('✅ File Format (save structure, serialization, name sanitization)');
-console.log('✅ Node Deletion (node removal, wire cleanup)');
-console.log('✅ Canvas Interaction (drop zones, context menus)');
-console.log('✅ Property Editor (data binding, updates)');
-console.log('✅ Validation Integration (valid/invalid data handling)');
-console.log('✅ Canvas Scrolling (bounds calculation, scroll triggers)');
-
-console.log('\n🔧 These tests validate the core functionality of your DxT application.');
-console.log('For UI interaction testing, run the application and test manually.');
-console.log('For validation system testing, run: npm test');

--- a/test/diagram-cleanup-cycle.test.cjs
+++ b/test/diagram-cleanup-cycle.test.cjs
@@ -1,0 +1,12 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+test('diagram cleanup includes cycle fallback logic', () => {
+  const appPath = path.resolve(__dirname, '../src/App.tsx')
+  const content = fs.readFileSync(appPath, 'utf8')
+  const cycleCommentPattern = /Fallback: handle any unprocessed nodes[\s\S]*cycles in the diagram/
+  const cycleWarnPattern = /Circular dependency detected in diagram/
+
+  expect(cycleCommentPattern.test(content)).toBe(true)
+  expect(cycleWarnPattern.test(content)).toBe(true)
+})

--- a/test/manual-internal-wiring-test.cjs
+++ b/test/manual-internal-wiring-test.cjs
@@ -4,24 +4,14 @@
 
 const fs = require('fs');
 
-console.log('=== Internal Wiring Transformation Test ===\n');
-
 // Load the test diagram
 const diagramData = JSON.parse(
   fs.readFileSync('./samples/test_internal_wiring_diagram.json', 'utf8')
 );
 
-console.log('1. Loaded test diagram:');
-console.log(`   - Nodes: ${diagramData.nodes.length}`);
-console.log(`   - Wires: ${diagramData.wires.length}`);
-
 // The Filter and Normalize nodes are connected internally
 const filterNode = diagramData.nodes.find(n => n.id === 'filter-node');
 const normalizeNode = diagramData.nodes.find(n => n.id === 'normalize-node');
-
-console.log('\n2. Selected nodes for transformation:');
-console.log(`   - Filter (${filterNode.id})`);
-console.log(`   - Normalize (${normalizeNode.id})`);
 
 // Get wires between these nodes
 const selectedNodeIds = [filterNode.id, normalizeNode.id];
@@ -29,28 +19,11 @@ const relevantWires = diagramData.wires.filter(w =>
   selectedNodeIds.includes(w.fromNodeId) || selectedNodeIds.includes(w.toNodeId)
 );
 
-console.log(`\n3. Wires related to selection: ${relevantWires.length}`);
-relevantWires.forEach(w => {
-  const isInternal = selectedNodeIds.includes(w.fromNodeId) && selectedNodeIds.includes(w.toNodeId);
-  console.log(`   - ${w.id}: ${w.fromNodeId} -> ${w.toNodeId} ${isInternal ? '(INTERNAL)' : '(EXTERNAL)'}`);
-});
-
 // Simulate what buildTransformationFromDiagram would do
 const selectedNodes = [filterNode, normalizeNode];
 const internalWires = diagramData.wires.filter(w => 
   selectedNodeIds.includes(w.fromNodeId) && selectedNodeIds.includes(w.toNodeId)
 );
-
-console.log('\n4. Internal wires that should be captured:');
-console.log(`   - Count: ${internalWires.length}`);
-if (internalWires.length > 0) {
-  internalWires.forEach((wire, i) => {
-    console.log(`   - Wire ${i+1}: ${wire.fromNodeId}[${wire.fromPortIdx}] -> ${wire.toNodeId}[${wire.toPortIdx}]`);
-  });
-  console.log('\n✅ Internal wires are present in the diagram');
-} else {
-  console.log('\n❌ No internal wires found');
-}
 
 // Create a sample transformation manually
 const transformation = {
@@ -64,13 +37,3 @@ const transformation = {
 // Save to file
 const transformationPath = './samples/test_generated_transformation.json';
 fs.writeFileSync(transformationPath, JSON.stringify(transformation, null, 2));
-console.log(`\n5. Saved transformation to: ${transformationPath}`);
-
-console.log('\n✅ Test Complete - You can now:');
-console.log('   1. Start the app with: npm run dev');
-console.log('   2. Load the test diagram: samples/test_internal_wiring_diagram.json');
-console.log('   3. Select the Filter and Normalize nodes');
-console.log('   4. Save as transformation to verify internal wiring is captured');
-console.log('   5. Delete the selected nodes');
-console.log('   6. Load the generated transformation: samples/test_generated_transformation.json');
-console.log('   7. Apply the transformation to verify internal wiring is recreated');

--- a/test/manual-internal-wiring-test.cjs
+++ b/test/manual-internal-wiring-test.cjs
@@ -1,39 +1,35 @@
-/**
- * Test script to demonstrate internal wiring in transformations
- */
+const fs = require('node:fs');
+const path = require('node:path');
 
-const fs = require('fs');
+test('internal wiring transformation fixture is generated', () => {
+  const diagramPath = path.resolve(__dirname, '../samples/test_internal_wiring_diagram.json');
+  const diagramData = JSON.parse(fs.readFileSync(diagramPath, 'utf8'));
 
-// Load the test diagram
-const diagramData = JSON.parse(
-  fs.readFileSync('./samples/test_internal_wiring_diagram.json', 'utf8')
-);
+  const filterNode = diagramData.nodes.find(n => n.id === 'filter-node');
+  const normalizeNode = diagramData.nodes.find(n => n.id === 'normalize-node');
 
-// The Filter and Normalize nodes are connected internally
-const filterNode = diagramData.nodes.find(n => n.id === 'filter-node');
-const normalizeNode = diagramData.nodes.find(n => n.id === 'normalize-node');
+  expect(filterNode).toBeTruthy();
+  expect(normalizeNode).toBeTruthy();
 
-// Get wires between these nodes
-const selectedNodeIds = [filterNode.id, normalizeNode.id];
-const relevantWires = diagramData.wires.filter(w => 
-  selectedNodeIds.includes(w.fromNodeId) || selectedNodeIds.includes(w.toNodeId)
-);
+  const selectedNodeIds = [filterNode.id, normalizeNode.id];
 
-// Simulate what buildTransformationFromDiagram would do
-const selectedNodes = [filterNode, normalizeNode];
-const internalWires = diagramData.wires.filter(w => 
-  selectedNodeIds.includes(w.fromNodeId) && selectedNodeIds.includes(w.toNodeId)
-);
+  const internalWires = diagramData.wires.filter(w =>
+    selectedNodeIds.includes(w.fromNodeId) && selectedNodeIds.includes(w.toNodeId)
+  );
 
-// Create a sample transformation manually
-const transformation = {
-  name: 'Filter+Normalize Chain',
-  inputPattern: ['in'],
-  outputPattern: ['out'],
-  replacementNodes: selectedNodes,
-  internalWires: internalWires
-};
+  expect(internalWires.length).toBeGreaterThan(0);
 
-// Save to file
-const transformationPath = './samples/test_generated_transformation.json';
-fs.writeFileSync(transformationPath, JSON.stringify(transformation, null, 2));
+  const transformation = {
+    name: 'Filter+Normalize Chain',
+    inputPattern: ['in'],
+    outputPattern: ['out'],
+    replacementNodes: [filterNode, normalizeNode],
+    internalWires,
+  };
+
+  const transformationPath = path.resolve(__dirname, '../samples/test_generated_transformation.json');
+  fs.writeFileSync(transformationPath, JSON.stringify(transformation, null, 2));
+
+  const output = JSON.parse(fs.readFileSync(transformationPath, 'utf8'));
+  expect(output.internalWires.length).toBe(internalWires.length);
+});

--- a/test/run-tests.cjs
+++ b/test/run-tests.cjs
@@ -1,36 +1,15 @@
 #!/usr/bin/env node
 
-// DxT Test Runner
-console.log('🚀 DxT Test Runner\n');
-
 const { spawn } = require('child_process');
 const path = require('path');
 
 async function runTest(testFile, testName, useTsx = false) {
     return new Promise((resolve) => {
-        console.log(`📋 Running ${testName}...`);
         const command = useTsx ? 'npx' : 'node';
         const args = useTsx ? ['tsx', testFile] : [testFile];
-        const child = spawn(command, args, { cwd: path.dirname(__filename), env: process.env });
-        
-        let output = '';
-        child.stdout.on('data', (data) => {
-            output += data.toString();
-        });
-        
-        child.stderr.on('data', (data) => {
-            output += data.toString();
-        });
-        
-        child.on('close', (code) => {
-            console.log(output);
-            if (code === 0) {
-                console.log(`✅ ${testName} completed successfully\n`);
-            } else {
-                console.log(`❌ ${testName} failed with exit code ${code}\n`);
-            }
-            resolve(code === 0);
-        });
+        const child = spawn(command, args, { cwd: path.dirname(__filename), env: process.env, stdio: 'ignore' });
+
+        child.on('close', (code) => resolve(code === 0));
     });
 }
 
@@ -48,14 +27,6 @@ async function runAllTests() {
         const passed = await runTest(test.file, test.name, test.useTsx);
         if (!passed) allPassed = false;
     }
-    
-    console.log('='.repeat(60));
-    if (allPassed) {
-        console.log('🎉 All test suites passed! Your DxT application is working correctly.');
-    } else {
-        console.log('⚠️  Some test suites failed. Please review the output above.');
-    }
-    console.log('='.repeat(60));
     
     return allPassed;
 }

--- a/test/transformation-applicability.test.cjs
+++ b/test/transformation-applicability.test.cjs
@@ -1,33 +1,13 @@
-// Transformation applicability tests
-console.log('=== Transformation Applicability Tests ===\n');
+let getApplicableTransformations;
 
-function runTest(testName, testFn) {
-    try {
-        const result = testFn();
-        if (result === true || result === undefined) {
-            console.log(`✅ ${testName}: PASSED`);
-            return true;
-        }
-        console.log(`❌ ${testName}: FAILED - ${result}`);
-        return false;
-    } catch (error) {
-        console.log(`❌ ${testName}: ERROR - ${error.message}`);
-        return false;
-    }
-}
+beforeAll(async () => {
+    ({ getApplicableTransformations } = await import('../src/utils/transformation.ts'));
+});
 
 function assertTrue(condition, message = '') {
     if (!condition) {
         throw new Error(message || 'Assertion failed');
     }
-}
-
-let total = 0;
-let passed = 0;
-
-function test(name, fn) {
-    total++;
-    if (runTest(name, fn)) passed++;
 }
 
 const nodes = [
@@ -95,31 +75,26 @@ const transformations = [
     }
 ];
 
-const run = async () => {
-    const { getApplicableTransformations } = await import('../src/utils/transformation.ts');
-
-    console.log('🔁 Applicability Matching:');
-
-    test('Transformation matches external ports of selection', () => {
+test('Transformation matches external ports of selection', () => {
         const selection = ['filter-1', 'normalize-1'];
         const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
         assertTrue(applicable.some(t => t.name === 'Filter + Normalize -> OptimizedFilter'), 'Expected applicable transform');
         assertTrue(!applicable.some(t => t.name === 'Mismatched Output'), 'Did not expect mismatched output transform');
     });
 
-    test('Internal wires are ignored when computing external ports', () => {
+test('Internal wires are ignored when computing external ports', () => {
         const selection = ['filter-1', 'normalize-1'];
         const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
         assertTrue(!applicable.some(t => t.name === 'Double Input Needed'), 'Internal port should not count as external');
     });
 
-    test('Unconnected ports are treated as external', () => {
+test('Unconnected ports are treated as external', () => {
         const selection = ['lonely-1'];
         const applicable = getApplicableTransformations(nodes, wires, selection, transformations);
         assertTrue(applicable.some(t => t.name === 'Filter + Normalize -> OptimizedFilter'), 'Unconnected ports should still match');
     });
 
-    test('Duplicate port names are matched as a multiset', () => {
+test('Duplicate port names are matched as a multiset', () => {
         const localNodes = [
             { id: 'src-a', type: 'Source', x: 50, y: 50, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
             { id: 'src-b', type: 'Source', x: 50, y: 120, properties: { name: 'Source', inputs: [], outputs: ['out'] } },
@@ -141,13 +116,4 @@ const run = async () => {
         assertTrue(applicable.length === 1, 'Expected multiset match for duplicate ports');
     });
 
-    console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
-    if (passed !== total) {
-        process.exitCode = 1;
-    }
-};
-
-run().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-});
+// === TEST SUMMARY ===

--- a/test/transformation-apply.test.cjs
+++ b/test/transformation-apply.test.cjs
@@ -1,20 +1,9 @@
-// Transformation apply and export tests
-console.log('=== Transformation Apply Tests ===\n');
+let applyTransformationToSelection;
+let buildTransformationFromDiagram;
 
-function runTest(testName, testFn) {
-    try {
-        const result = testFn();
-        if (result === true || result === undefined) {
-            console.log(`✅ ${testName}: PASSED`);
-            return true;
-        }
-        console.log(`❌ ${testName}: FAILED - ${result}`);
-        return false;
-    } catch (error) {
-        console.log(`❌ ${testName}: ERROR - ${error.message}`);
-        return false;
-    }
-}
+beforeAll(async () => {
+    ({ applyTransformationToSelection, buildTransformationFromDiagram } = await import('../src/utils/transformation.ts'));
+});
 
 function assertTrue(condition, message = '') {
     if (!condition) {
@@ -22,24 +11,9 @@ function assertTrue(condition, message = '') {
     }
 }
 
-function assertEqual(actual, expected, message = '') {
-    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}. ${message}`);
-    }
+function assertEqual(actual, expected) {
+    expect(actual).toEqual(expected);
 }
-
-let total = 0;
-let passed = 0;
-
-function test(name, fn) {
-    total++;
-    if (runTest(name, fn)) passed++;
-}
-
-const run = async () => {
-    const { applyTransformationToSelection, buildTransformationFromDiagram } = await import('../src/utils/transformation.ts');
-
-    console.log('🧪 Transformation Export:');
 
     test('Unwired ports become transformation patterns', () => {
         const nodes = [
@@ -67,8 +41,6 @@ const run = async () => {
         assertEqual(transformation.outputPattern, ['out']);
         assertTrue(transformation.replacementNodes.length === 2, 'Expected nodes to be included');
     });
-
-    console.log('\n🔁 Transformation Apply:');
 
     test('Apply transformation rewires external connections', () => {
         const nodes = [
@@ -154,8 +126,6 @@ const run = async () => {
         assertTrue(result !== null, 'Expected transformation to apply');
         assertTrue(result.wires.length === 2, 'Expected only existing external wires to be rewired');
     });
-
-    console.log('\n🔗 Internal Wiring Tests:');
 
     test('buildTransformationFromDiagram captures internal wires', () => {
         const nodes = [
@@ -253,8 +223,6 @@ const run = async () => {
 
         assertTrue(result.wires.length === 4, `Expected 4 wires (2 internal + 2 external), got ${result.wires.length}`);
     });
-
-    console.log('\n🐛 Duplicate Port Name Tests:');
 
     test('Apply transformation prefers unwired output ports over internally-wired ones', () => {
         const nodes = [
@@ -369,13 +337,4 @@ const run = async () => {
         assertEqual(wiresFromSrc2[0].toPortIdx, 0, 'Both wires should go to port 0');
     });
 
-    console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
-    if (passed !== total) {
-        process.exitCode = 1;
-    }
-};
-
-run().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-});
+// === TEST SUMMARY ===

--- a/test/transformation-utils.test.cjs
+++ b/test/transformation-utils.test.cjs
@@ -1,0 +1,48 @@
+let getPortList
+let arePortMultisetsEqual
+let getExternalPorts
+
+beforeAll(async () => {
+  ({ getPortList, arePortMultisetsEqual, getExternalPorts } = await import('../src/utils/transformation.ts'))
+})
+
+test('getPortList returns string arrays and ignores invalid values', () => {
+  expect(getPortList({ inputs: ['a', 'b'] }, 'inputs')).toEqual(['a', 'b'])
+  expect(getPortList({ inputs: ['a', 1] }, 'inputs')).toEqual([])
+  expect(getPortList({ outputs: 'nope' }, 'outputs')).toEqual([])
+})
+
+test('arePortMultisetsEqual matches duplicates regardless of order', () => {
+  expect(arePortMultisetsEqual(['a', 'b', 'a'], ['b', 'a', 'a'])).toBe(true)
+  expect(arePortMultisetsEqual(['a', 'b'], ['a', 'b', 'b'])).toBe(false)
+})
+
+test('getExternalPorts treats unwired ports as external', () => {
+  const nodes = [
+    { id: 'a', type: 'A', x: 0, y: 0, properties: { inputs: ['in'], outputs: ['out'] } },
+    { id: 'b', type: 'B', x: 0, y: 0, properties: { inputs: ['in'], outputs: ['out'] } },
+  ]
+  const wires = [
+    { id: 'w1', fromNodeId: 'a', fromPortIdx: 0, toNodeId: 'b', toPortIdx: 0 },
+  ]
+
+  const { externalInputs, externalOutputs } = getExternalPorts(nodes, wires, ['a', 'b'])
+  expect(externalInputs.map(p => p.name)).toEqual(['in'])
+  expect(externalOutputs.map(p => p.name)).toEqual(['out'])
+})
+
+test('getExternalPorts only includes ports crossing selection boundary', () => {
+  const nodes = [
+    { id: 'src', type: 'Source', x: 0, y: 0, properties: { inputs: [], outputs: ['out'] } },
+    { id: 'mid', type: 'Mid', x: 0, y: 0, properties: { inputs: ['in'], outputs: ['out'] } },
+    { id: 'sink', type: 'Sink', x: 0, y: 0, properties: { inputs: ['in'], outputs: [] } },
+  ]
+  const wires = [
+    { id: 'w1', fromNodeId: 'src', fromPortIdx: 0, toNodeId: 'mid', toPortIdx: 0 },
+    { id: 'w2', fromNodeId: 'mid', fromPortIdx: 0, toNodeId: 'sink', toPortIdx: 0 },
+  ]
+
+  const { externalInputs, externalOutputs } = getExternalPorts(nodes, wires, ['mid'])
+  expect(externalInputs.map(p => p.name)).toEqual(['in'])
+  expect(externalOutputs.map(p => p.name)).toEqual(['out'])
+})

--- a/test/validation-format.test.cjs
+++ b/test/validation-format.test.cjs
@@ -1,0 +1,21 @@
+let formatValidationErrors
+
+beforeAll(async () => {
+  ({ formatValidationErrors } = await import('../src/utils/validation.ts'))
+})
+
+test('formatValidationErrors returns empty string when no errors', () => {
+  const message = formatValidationErrors([])
+  expect(message).toBe('')
+})
+
+test('formatValidationErrors includes paths and messages', () => {
+  const message = formatValidationErrors([
+    { path: 'nodes[0].id', message: 'Missing required property' },
+    { path: '', message: 'Top-level error' },
+  ])
+
+  expect(message).toContain('Validation errors:')
+  expect(message).toContain('nodes[0].id: Missing required property')
+  expect(message).toContain('Top-level error')
+})

--- a/test/validation-test.cjs
+++ b/test/validation-test.cjs
@@ -1,33 +1,15 @@
-// JSON Schema Validation Tests (real schema validation)
-console.log('=== JSON Schema Validation Tests ===\n');
+let validateDiagram;
+let validatePalette;
+let validateTransformation;
 
-function runTest(testName, testFn) {
-    try {
-        const result = testFn();
-        if (result === true || result === undefined) {
-            console.log(`✅ ${testName}: PASSED`);
-            return true;
-        }
-        console.log(`❌ ${testName}: FAILED - ${result}`);
-        return false;
-    } catch (error) {
-        console.log(`❌ ${testName}: ERROR - ${error.message}`);
-        return false;
-    }
-}
+beforeAll(async () => {
+    ({ validateDiagram, validatePalette, validateTransformation } = await import('../src/utils/validation.ts'));
+});
 
 function assertTrue(condition, message = '') {
     if (!condition) {
         throw new Error(message || 'Assertion failed');
     }
-}
-
-let total = 0;
-let passed = 0;
-
-function test(name, fn) {
-    total++;
-    if (runTest(name, fn)) passed++;
 }
 
 const validDiagram = {
@@ -125,106 +107,88 @@ const invalidTransformation = {
     replacementNodes: []
 };
 
-const run = async () => {
-    const { validateDiagram, validatePalette, validateTransformation } = await import('../src/utils/validation.ts');
+test('Valid diagram passes validation', () => {
+    const errors = validateDiagram(validDiagram);
+    assertTrue(errors.length === 0, 'Expected no validation errors');
+});
 
-    console.log('🔎 Diagram Schema Validation:');
-    test('Valid diagram passes validation', () => {
-        const errors = validateDiagram(validDiagram);
-        assertTrue(errors.length === 0, 'Expected no validation errors');
-    });
+test('Invalid diagram fails validation', () => {
+    const errors = validateDiagram(invalidDiagram);
+    assertTrue(errors.length > 0, 'Expected validation errors');
+});
 
-    test('Invalid diagram fails validation', () => {
-        const errors = validateDiagram(invalidDiagram);
-        assertTrue(errors.length > 0, 'Expected validation errors');
-    });
+test('Valid palette passes validation', () => {
+    const errors = validatePalette(validPalette);
+    assertTrue(errors.length === 0, 'Expected no validation errors');
+});
 
-    console.log('\n🎨 Palette Schema Validation:');
-    test('Valid palette passes validation', () => {
-        const errors = validatePalette(validPalette);
-        assertTrue(errors.length === 0, 'Expected no validation errors');
-    });
+test('Invalid palette fails validation', () => {
+    const errors = validatePalette(invalidPalette);
+    assertTrue(errors.length > 0, 'Expected validation errors');
+});
 
-    test('Invalid palette fails validation', () => {
-        const errors = validatePalette(invalidPalette);
-        assertTrue(errors.length > 0, 'Expected validation errors');
-    });
+test('Valid transformation passes validation', () => {
+    const errors = validateTransformation(validTransformation);
+    assertTrue(errors.length === 0, 'Expected no validation errors');
+});
 
-    console.log('\n🔁 Transformation Schema Validation:');
-    test('Valid transformation passes validation', () => {
-        const errors = validateTransformation(validTransformation);
-        assertTrue(errors.length === 0, 'Expected no validation errors');
-    });
+test('Invalid transformation fails validation', () => {
+    const errors = validateTransformation(invalidTransformation);
+    assertTrue(errors.length > 0, 'Expected validation errors');
+});
 
-    test('Invalid transformation fails validation', () => {
-        const errors = validateTransformation(invalidTransformation);
-        assertTrue(errors.length > 0, 'Expected validation errors');
-    });
+test('Empty port arrays are allowed', () => {
+    const diagram = {
+        name: 'Empty Ports',
+        nodes: [
+            {
+                id: 'node1',
+                type: 'Empty',
+                x: 0,
+                y: 0,
+                properties: { name: 'Empty', inputs: [], outputs: [] }
+            }
+        ],
+        customNodeDefs: [],
+        wires: []
+    };
+    const errors = validateDiagram(diagram);
+    assertTrue(errors.length === 0, 'Expected empty port arrays to be valid');
+});
 
-    console.log('\n🧩 Schema Edge Cases:');
-    test('Empty port arrays are allowed', () => {
-        const diagram = {
-            name: 'Empty Ports',
-            nodes: [
-                {
-                    id: 'node1',
-                    type: 'Empty',
-                    x: 0,
-                    y: 0,
-                    properties: { name: 'Empty', inputs: [], outputs: [] }
-                }
-            ],
-            customNodeDefs: [],
-            wires: []
-        };
-        const errors = validateDiagram(diagram);
-        assertTrue(errors.length === 0, 'Expected empty port arrays to be valid');
-    });
+test('Invalid port name fails validation', () => {
+    const badPalette = [
+        { name: 'BadPort', inputs: [''], outputs: ['out'] }
+    ];
+    const errors = validatePalette(badPalette);
+    assertTrue(errors.length > 0, 'Expected invalid port name error');
+});
 
-    test('Invalid port name fails validation', () => {
-        const badPalette = [
-            { name: 'BadPort', inputs: [''], outputs: ['out'] }
-        ];
-        const errors = validatePalette(badPalette);
-        assertTrue(errors.length > 0, 'Expected invalid port name error');
-    });
+test('Node properties must be an object', () => {
+    const diagram = {
+        name: 'Bad Properties',
+        nodes: [
+            {
+                id: 'node1',
+                type: 'Bad',
+                x: 0,
+                y: 0,
+                properties: 'not-an-object'
+            }
+        ],
+        customNodeDefs: [],
+        wires: []
+    };
+    const errors = validateDiagram(diagram);
+    assertTrue(errors.length > 0, 'Expected invalid properties error');
+});
 
-    test('Node properties must be an object', () => {
-        const diagram = {
-            name: 'Bad Properties',
-            nodes: [
-                {
-                    id: 'node1',
-                    type: 'Bad',
-                    x: 0,
-                    y: 0,
-                    properties: 'not-an-object'
-                }
-            ],
-            customNodeDefs: [],
-            wires: []
-        };
-        const errors = validateDiagram(diagram);
-        assertTrue(errors.length > 0, 'Expected invalid properties error');
-    });
-
-    test('Missing diagram name fails validation', () => {
-        const diagram = {
-            nodes: [],
-            customNodeDefs: [],
-            wires: []
-        };
-        const errors = validateDiagram(diagram);
-        assertTrue(errors.length > 0, 'Expected missing name error');
-    });
-
-    console.log(`\n=== Test Summary: ${passed}/${total} passed ===`);
-    if (passed !== total) {
-        process.exitCode = 1;
-    }
-};
-
-run().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
+test('Missing diagram name fails validation', () => {
+    const diagram = {
+        nodes: [],
+        customNodeDefs: [],
+        wires: []
+    };
+    const errors = validateDiagram(diagram);
+    assertTrue(errors.length > 0, 'Expected missing name error');
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,4 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  test: {
-    environment: 'node',
-    include: ['test/**/*.test.cjs'],
-  },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.cjs'],
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['test/**/*.test.cjs'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['test/**/*.test.cjs'],
+    include: ['test/**/*test.cjs'],
   },
 })


### PR DESCRIPTION
- Updated package.json to replace existing test commands with Vitest commands.
- Refactored app-functionality tests to use Vitest's assertion methods and removed manual test logging.
- Simplified internal wiring test by removing console logs and restructuring the test flow.
- Modified run-tests script to streamline test execution and removed unnecessary logging.
- Refactored transformation applicability tests to utilize Vitest's beforeAll and assertion methods.
- Updated transformation apply tests to use Vitest's assertion methods and removed manual test logging.
- Refactored validation tests to utilize Vitest's assertion methods and removed manual test logging.
- Configured Vite and added a new Vitest configuration file for test environment setup.